### PR TITLE
terraform improvements: Backend access groups, Admin consent

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -32,3 +32,26 @@ locals {
 locals {
   verified_id_create_presentation_request_uri = "https://verifiedid.did.msidentity.com/v1.0/verifiableCredentials/createPresentationRequest"
 }
+
+locals {
+  backend_access_groups_map = {
+    "CreateTAP" = {
+      group_name = "sec - MyWorkID - Create TAP"
+      app_role   = "MyWorkID.CreateTAP"
+    }
+    "DismissUserRisk" = {
+      group_name = "sec - MyWorkID - Dismiss User Risk"
+      app_role   = "MyWorkID.DismissUserRisk"
+    }
+    "PasswordReset" = {
+      group_name = "sec - MyWorkID - Password Reset"
+      app_role   = "MyWorkID.PasswordReset"
+    }
+    "ValidateIdentity" = {
+      group_name = "sec - MyWorkID - Validate Identity"
+      app_role   = "MyWorkID.ValidateIdentity"
+    }
+  }
+
+  base_access_groups_map = { for k, v in local.backend_access_groups_map : k => v if var.create_backend_access_groups && !var.skip_actions_requiring_global_admin }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -269,3 +269,19 @@ resource "azurerm_role_assignment" "backend_key_vault_access" {
   role_definition_name = "Key Vault Secrets User"
   principal_id         = azurerm_linux_web_app.backend.identity[0].principal_id
 }
+
+resource "azuread_group" "backend_access" {
+  for_each = local.base_access_groups_map
+
+  display_name     = each.value.group_name
+  description      = "Access group for MyWorkID backend permission ${each.value.app_role}"
+  security_enabled = true
+}
+
+resource "azuread_app_role_assignment" "backend_access" {
+  for_each = local.base_access_groups_map
+
+  app_role_id         = azuread_service_principal.backend.app_role_ids[each.value.app_role]
+  principal_object_id = azuread_group.backend_access[each.key].object_id
+  resource_object_id  = azuread_service_principal.backend.object_id
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -57,6 +57,12 @@ variable "skip_actions_requiring_global_admin" {
   type        = bool
   default     = false
 }
+
+variable "create_backend_access_groups" {
+  description = "Create access groups for the backend. Also requires Global Administrator privileges"
+  type        = bool
+  default     = true
+}
 variable "binaries_zip_path" {
   type        = string
   description = "Path where binaries are located"


### PR DESCRIPTION
This pull request includes several changes to the Terraform configuration to simplify the setup for end-users.
* There is now a default-enabled option `create_backend_access_groups` the controls if groups for each backend App Role are created and assigned the respective app roles.
* The admin consent for the `Access` OAuth scope on the backend is granted by default on the frontend App registration.

Enhancements to access management:

* [`terraform/locals.tf`](diffhunk://#diff-1e88310e1535b90c37b1069d56c203a3a4f406bd3a8b17d701a9b65c443e4193R35-R57): Added a new local map `backend_access_groups_map` to define backend access groups and a derived map `base_access_groups_map` to conditionally create these groups based on new variables.

* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R128-R134): Introduced a new resource `azuread_service_principal_delegated_permission_grant` to grant delegated permissions from frontend to backend service principals.

* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R272-R287): Added new resources `azuread_group` and `azuread_app_role_assignment` to create backend access groups and assign app roles to these groups.

Introduction of new variables:

* [`terraform/variables.tf`](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R60-R65): Added a new variable `create_backend_access_groups` to control the creation of backend access groups, which also requires Global Administrator privileges.