### PR TITLE
change expected response from 400 -> 500

### DIFF
--- a/tests/MyWorkID.Server.IntegrationTests/Features/VerifiedId/ValidateIdentityTests.cs
+++ b/tests/MyWorkID.Server.IntegrationTests/Features/VerifiedId/ValidateIdentityTests.cs
@@ -83,13 +83,13 @@ namespace MyWorkID.Server.IntegrationTests.Features.VerifiedId
         }
 
         [Fact]
-        public async Task ValidateIdentity_Returns400_WithoutPresentation()
+        public async Task ValidateIdentity_Returns500_WithoutPresentation()
         {
             var handler = new MockHttpMessageHandler(HttpStatusCode.OK, null);
             var provider = new TestClaimsProvider().WithValidateIdentityRole().WithRandomSubAndOid();
             var client = _testApplicationFactory.WithHttpMock(handler).CreateClientWithTestAuth(provider);
             var response = await client.PostAsync(_baseUrl, null);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         }
 
         [Fact]


### PR DESCRIPTION
closes #43

This pull request includes a change to the `ValidateIdentity_Returns204_WithPresentation` method in the `ValidateIdentityTests.cs` file. The change updates the expected status code in the `ValidateIdentity_Returns400_WithoutPresentation` test method to reflect a different error condition.

Most important change:

* [`tests/MyWorkID.Server.IntegrationTests/Features/VerifiedId/ValidateIdentityTests.cs`](diffhunk://#diff-fc29bd2cd11ab03f86fc4dc1f4af486445ef9f2c3d40f1e7ccdb11e98d2cdc80L86-R92): Modified the `ValidateIdentity_Returns400_WithoutPresentation` test method to expect a `500 Internal Server Error` status code instead of a `400 Bad Request` status code.