### PR TITLE
Skip Sonar workflow in fork repositories

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,6 +17,7 @@ jobs:
   sonar:
     name: Sonar
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This change ensures that the Sonar workflow does not run in fork repositories. 
This is needed as fork repositories do not have the necessary GitHub Action secrets to access the SonarQube instance.