### PR TITLE
add dotnet test CI workflow

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,0 +1,42 @@
+name: 'Test CI'
+
+on:
+  pull_request:
+
+env:
+  DOTNET_CORE_VERSION: 8.0.x
+
+jobs:
+  run-tests:
+    name: run tests
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore NuGet Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('src/MyWorkID.Server') }}
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
+      - name: Build
+        run: |
+          dotnet restore
+          dotnet build --configuration Release --no-restore
+      - name: Test
+        run: |
+          dotnet test --logger "trx;logfilename=testResults.trx"
+      - name: Gather Test Results
+        if: success() || failure()
+        run: |
+          mkdir TestResults
+          cp tests/MyWorkID.Server.IntegrationTests/TestResults/testResults.trx TestResults/Integration-Tests.trx
+          cp tests/MyWorkID.Server.UnitTests/TestResults/testResults.trx TestResults/Unit-Tests.trx
+      - uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: testResults
+          path: TestResults/*.trx

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,22 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['Test CI']
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: testResults
+        name: test report
+        path: '*.trx'
+        reporter: dotnet-trx


### PR DESCRIPTION
resolves #42 

This pull request introduces new GitHub workflows to automate testing and test reporting for the project. The changes include setting up a continuous integration (CI) workflow to run tests on pull requests and a workflow to generate test reports.

New GitHub workflows:

* [`.github/workflows/test-ci.yml`](diffhunk://#diff-6fc0cfc32988f2cc6b9a0f5b8160950c4ca1c13d1159f326bf8a8841676fdca0R1-R42): Added a CI workflow named 'Test CI' that runs on pull requests. It sets up the .NET Core environment, restores NuGet packages, builds the project, runs tests, and uploads the test results as artifacts.
* [`.github/workflows/test-report.yml`](diffhunk://#diff-f23e09a20042156596d85e139423b1991e5ad593ee212cbdacecdef8edcc3027R1-R22): Added a workflow named 'Test Report' that triggers upon completion of the 'Test CI' workflow. It uses the `dorny/test-reporter` action to generate a test report from the test results artifacts.

Separating this into two different workflows is required as workflows triggered by pull requests from forked repositories are executed with read-only token and therefore can't create check runs (which are needed for displaying the test report table).

![image](https://github.com/user-attachments/assets/fc4c0744-8255-45b7-a01c-893dc7251ed0)
![image](https://github.com/user-attachments/assets/b3a36c8e-396b-4c74-9f87-734bdca3f2e0)



