### PR TITLE
add admin grant for user.read delegated permission

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -249,6 +249,7 @@ resource "azuread_service_principal" "msgraph" {
   use_existing = true
 }
 resource "azuread_service_principal_delegated_permission_grant" "frontend" {
+  count                                = local.skip_actions_requiring_global_admin ? 0 : 1
   service_principal_object_id          = azuread_service_principal.frontend.id
   resource_service_principal_object_id = azuread_service_principal.msgraph.object_id
   claim_values                         = ["User.Read"]


### PR DESCRIPTION
closes #36 

This pull request includes changes to the `terraform/main.tf` file to add new EntraId service principals and permission grants. The most important changes are as follows:

### Azure AD Service Principals

* Added a new `azuread_service_principal` resource for `msgraph` with the client ID set to Microsoft's Graph API and the `use_existing` attribute set to true.

### Permission Grants

* Added a new `azuread_service_principal_delegated_permission_grant` resource to grant the `frontend` service principal the `User.Read` permission on the `msgraph` service principal.