### PR TITLE
Fix mailto link in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📧 Get in touch
-    url: mailto:sales@glueckkanja.com
+    url: https://aka.c4a8.net/mailto-sales
     about: For inquiries and additional (potentially paid) setup support


### PR DESCRIPTION
closes #68 
This pull request includes a change to the `.github/ISSUE_TEMPLATE/config.yml` file to update the contact URL for inquiries and additional support.

* Updated the contact URL from `mailto:sales@glueckkanja.com` to `https://aka.c4a8.net/mailto-sales` for the "📧 Get in touch" link.