### PR TITLE
TAP Password -> Pass

### DIFF
--- a/src/MyWorkID.Client/src/components/function-plane/function-plane-components/create-tap.tsx
+++ b/src/MyWorkID.Client/src/components/function-plane/function-plane-components/create-tap.tsx
@@ -83,7 +83,7 @@ export const CreateTAP = (props: TFunctionProps) => {
             </CardTitle>
           </CardHeader>
           <CardFooter className="action-card__footer">
-            Create Temporary Access Password
+            Create Temporary Access Pass
           </CardFooter>
         </Card>
       ) : tapDisplay.loading ? (


### PR DESCRIPTION
closes #77 

Rename "Temporary Access Password" to "Temporary Access Pass"

This pull request includes a minor change to the `src/MyWorkID.Client/src/components/function-plane/function-plane-components/create-tap.tsx` file. The change updates the text displayed in the `CardFooter` component.

* [`src/MyWorkID.Client/src/components/function-plane/function-plane-components/create-tap.tsx`](diffhunk://#diff-550bb21eb100fec5b1f71e00b0e131ed1e5775d45e18efeb440de456dd1dd837L86-R86): Changed the text from "Create Temporary Access Password" to "Create Temporary Access Pass".