### PR TITLE
Change resource_provider_registrations to "extended"

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -16,7 +16,7 @@ terraform {
 }
 
 provider "azurerm" {
-  resource_provider_registrations = "none"
+  resource_provider_registrations = "extended"
   tenant_id                       = local.tenant_id
   subscription_id                 = local.subscription_id
   features {}


### PR DESCRIPTION
This pull request includes a change to the `terraform/providers.tf` file to modify the Azure Resource Manager provider configuration.

Configuration change:

* [`terraform/providers.tf`](diffhunk://#diff-832814fa1c0667ba9deaf8d383b5c47d12158b43b25f78eb1363418b0e83cc46L19-R19): Changed the `resource_provider_registrations` setting from "none" to "extended" in the `azurerm` provider block.