### PR TITLE
Revert "Change resource_provider_registrations to "extended""

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -16,7 +16,7 @@ terraform {
 }
 
 provider "azurerm" {
-  resource_provider_registrations = "extended"
+  resource_provider_registrations = "none"
   tenant_id                       = local.tenant_id
   subscription_id                 = local.subscription_id
   features {}


### PR DESCRIPTION
Reverts glueckkanja/MyWorkID#80

After reconsideration it was decided to extend the documentation rather than changing this property to have a more granular provider registration