### PR TITLE
Add allow_credential_operations_for_privileged_users

### DIFF
--- a/terraform/config.auto.tfvars.advanced.sample
+++ b/terraform/config.auto.tfvars.advanced.sample
@@ -19,6 +19,9 @@ skip_creation_backend_access_groups = false
 # NOTE: If this ever was set to false a change to true will result in the backend being recreated automatically
 enable_auto_update = true
 
+# Allow credential operations for privileged users. If set to true, users with privileged roles (e.g. Global Admin or User Admin) can perform credential operations like create TAP and reset password
+allow_credential_operations_for_privileged_users = false
+
 # ------- AppService -------
 
 # Name of the AppService that hosts the api. Note this has to be globally unique.

--- a/terraform/config.auto.tfvars.sample
+++ b/terraform/config.auto.tfvars.sample
@@ -10,3 +10,4 @@ reset_password_auth_context_id                   = "REPLACE_WITH_AUTHCONTEXT" # 
 skip_creation_backend_access_groups              = false # Value to determine if the backend access groups should be created automatically or if this action should be skipped
 skip_actions_requiring_global_admin              = false # Skip actions that require global admin permissions. If set to true you will have to set some settings, like the permission grants, manually. NOTE: If this ever was set to false a change to true will result in the previously set permissions being removed
 enable_auto_update                               = true # Determines if MyWorkID automatically updates with the most recent binaries published in github
+allow_credential_operations_for_privileged_users = false # Allow credential operations for privileged users. If set to true, users with privileged roles (e.g. Global Admin or User Admin) can perform credential operations like create TAP and reset password

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -17,6 +17,7 @@ locals {
   verified_id_verify_security_attribute            = var.verified_id_verify_security_attribute
   custom_domains                                   = var.custom_domains
   enable_auto_update                               = var.enable_auto_update
+  allow_credential_operations_for_privileged_users = var.allow_credential_operations_for_privileged_users
 }
 
 # Permissions necessary for the banend managed identity

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -107,8 +107,7 @@ resource "azuread_app_role_assignment" "backend_managed_identity" {
 # Necessary for the backend to be able to create taps and change the password of users - The password cannot be changed for users with some privilaged permissions - if it is desired to change the password of users with these permissions, the backend must have higher roles - for more info see https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/privileged-roles-permissions?tabs=admin-center#who-can-reset-passwords and https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-temporary-access-pass#create-a-temporary-access-pass
 resource "azuread_directory_role" "authentication_administrator" {
   count        = local.skip_actions_requiring_global_admin ? 0 : 1
-  display_name = "Authentication Administrator"
-  # display_name = "Privileged Authentication Administrator" #Necessary if privilaged users should also be able to use all functions (createTAP & changePassword) via MyWorkID
+  display_name = local.allow_credential_operations_for_privileged_users ? "Privileged Authentication Administrator" : "Authentication Administrator"
 }
 
 resource "time_sleep" "wait_30_seconds_after_user_assigned_identity_creation" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,6 +30,11 @@ variable "enable_auto_update" {
   description = "Decides wether the backend should be updated automatically. If set to false the backend will not be updated automatically. If set to true the backend will be updated automatically. NOTE: If this ever was set to false a change to true will result in the backend being recreated automatically"
   default = true
 }
+variable "allow_credential_operations_for_privileged_users"{
+  type = bool
+  description = "Allow credential operations for privileged users. If set to true, users with privileged roles (e.g. Global Admin or User Admin) can perform credential operations like create TAP and reset password"
+  default = false
+}
 
 # AppService
 variable "api_name" {


### PR DESCRIPTION
closes #89 
This pull request introduces a new configuration option to allow credential operations for privileged users. This change affects several Terraform configuration files to support the new option and ensure it is correctly applied throughout the system.

Key changes include:

* Configuration Updates:
  * Added `allow_credential_operations_for_privileged_users` variable to `terraform/variables.tf` with a default value of `false`.
  * Updated `terraform/config.auto.tfvars.advanced.sample` and `terraform/config.auto.tfvars.sample` to include the new `allow_credential_operations_for_privileged_users` setting. [[1]](diffhunk://#diff-592fbb792a908d4f638759b84e57a0610767d63d4dd1d4a5afb814a700e1dd94R22-R24) [[2]](diffhunk://#diff-8fc5e6fe1bf6d551804c00e135ce5f804da6f48bb4f333d3f7bb4235cceebc3bR13)

* Local Variables:
  * Added `allow_credential_operations_for_privileged_users` to the local variables in `terraform/locals.tf`.

* Role Assignment:
  * Modified `azuread_app_role_assignment` in `terraform/main.tf` to conditionally set the `display_name` based on the new `allow_credential_operations_for_privileged_users` variable.