### PR TITLE
change myWordID Logo to MyWorkID

### DIFF
--- a/src/MyWorkID.Client/src/components/header.tsx
+++ b/src/MyWorkID.Client/src/components/header.tsx
@@ -22,7 +22,7 @@ export const Header = () => {
     <div className="header__container">
       <img src={HeaderLogoSvg} alt="myWorkID Logo" />
       <div className="header__title">
-        <span className="header__title__text-myWork">myWork</span>
+        <span className="header__title__text-myWork">MyWork</span>
         <span className="header__title__text-ID">ID</span>
       </div>
       <button


### PR DESCRIPTION
closes #91 

This pull request includes a minor change to the `header.tsx` file to correct the capitalization of the "MyWork" text in the header title.

* [`src/MyWorkID.Client/src/components/header.tsx`](diffhunk://#diff-fd6214705ad0e847013e7fd7ef638240a862316ce81d39c68e882b3511b39c76L25-R25): Changed the text from "myWork" to "MyWork" in the header title.