### PR TITLE
ci: add dependabot config to update GitHub Actions weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request adds a configuration file to enable automated dependency updates for GitHub Actions using Dependabot.

Dependency management:

* Added `.github/dependabot.yml` to configure Dependabot to check for updates to GitHub Actions workflows on a weekly schedule.

fixes https://github.com/glueckkanja/MyWorkID/issues/52