### PR TITLE
fix: update TAP lifetime validation range to 60-480 minutes

### DIFF
--- a/src/MyWorkID.Server/Options/TapOptions.cs
+++ b/src/MyWorkID.Server/Options/TapOptions.cs
@@ -10,9 +10,10 @@ namespace MyWorkID.Server.Options
         public const string SectionName = "Tap";
 
         /// <summary>
-        /// Overrides the TAP lifetime in minutes. Graph enforces 10-43200 minutes.
+        /// Overrides the TAP lifetime in minutes. Graph API enforces 60-480 minutes.
+        /// Note: Official Microsoft documentation may show different ranges, but the actual API validation requires 60-480.
         /// </summary>
-        [Range(10, 43200, ErrorMessage = "The field 'LifetimeInMinutes' must be between 10 and 43200.")]
+        [Range(60, 480, ErrorMessage = "The field 'LifetimeInMinutes' must be between 60 and 480.")]
         public int? LifetimeInMinutes { get; set; }
 
         /// <summary>

--- a/terraform/config.auto.tfvars.advanced.sample
+++ b/terraform/config.auto.tfvars.advanced.sample
@@ -69,7 +69,8 @@ verified_id_face_match_confidence_threshold = 70
 
 # ------- Tap Settings -------
 
-# Optional override for the TAP lifetime (minutes). Must be between 10 and 43200 when set.
+# Optional override for the TAP lifetime (minutes). Must be between 60 and 480 when set.
+# Note: Official Microsoft documentation may show different ranges, but Graph API enforces 60-480.
 tap_lifetime_in_minutes = null
 
 # Optional override deciding whether generated TAPs can be used only once.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -110,15 +110,15 @@ variable "verified_id_face_match_confidence_threshold" {
 # Tap settings
 variable "tap_lifetime_in_minutes" {
   type        = number
-  description = "Optional override for the TAP lifetime (in minutes). Graph enforces 10-43200 minutes."
+  description = "Optional override for the TAP lifetime (in minutes). Graph API enforces 60-480 minutes. Note: Official Microsoft documentation may differ, but actual API validation requires this range."
   default     = null
   nullable    = true
   validation {
     condition = var.tap_lifetime_in_minutes == null || (
-      var.tap_lifetime_in_minutes >= 10 &&
-      var.tap_lifetime_in_minutes <= 43200
+      var.tap_lifetime_in_minutes >= 60 &&
+      var.tap_lifetime_in_minutes <= 480
     )
-    error_message = "Must be null or between 10 and 43200 (inclusive)."
+    error_message = "Must be null or between 60 and 480 (inclusive). Note: Official documentation may show different ranges, but Graph API enforces 60-480."
   }
 }
 

--- a/tests/MyWorkID.Server.UnitTests/Configuration/TapConfigurationValidationTests.cs
+++ b/tests/MyWorkID.Server.UnitTests/Configuration/TapConfigurationValidationTests.cs
@@ -38,17 +38,17 @@ namespace MyWorkID.Server.UnitTests.Configuration
             {
                 {
                     TestConfigurationSection.Create(
-                        ("Tap:LifetimeInMinutes", "9")
+                        ("Tap:LifetimeInMinutes", "59")
                     ),
                     typeof(OptionsValidationException),
-                    "The field 'LifetimeInMinutes' must be between 10 and 43200."
+                    "The field 'LifetimeInMinutes' must be between 60 and 480."
                 },
                 {
                     TestConfigurationSection.Create(
-                        ("Tap:LifetimeInMinutes", "43201")
+                        ("Tap:LifetimeInMinutes", "481")
                     ),
                     typeof(OptionsValidationException),
-                    "The field 'LifetimeInMinutes' must be between 10 and 43200."
+                    "The field 'LifetimeInMinutes' must be between 60 and 480."
                 },
                 {
                     TestConfigurationSection.Create(),
@@ -57,7 +57,7 @@ namespace MyWorkID.Server.UnitTests.Configuration
                 },
                 {
                     TestConfigurationSection.Create(
-                        ("Tap:LifetimeInMinutes", "30"),
+                        ("Tap:LifetimeInMinutes", "60"),
                         ("Tap:IsUsableOnce", "true")
                     ),
                     null,


### PR DESCRIPTION
closes #123 

This pull request updates the allowed range for the TAP (Token Access Policy) lifetime configuration across the codebase to reflect the actual validation enforced by the Microsoft Graph API (60–480 minutes), rather than the previously documented (but incorrect) range. It also ensures that documentation, validation logic, and tests are consistent with this enforced range.

**Configuration and Validation Updates:**

* Updated the `LifetimeInMinutes` property in `TapOptions` (`TapOptions.cs`) to require a value between 60 and 480 minutes, and clarified the summary comment to note the discrepancy with official Microsoft documentation.
* Changed the validation logic and error messages for the `tap_lifetime_in_minutes` variable in Terraform configuration (`variables.tf`) to enforce the 60–480 minute range, and updated the description to clarify the actual API requirements.
* Updated the sample Terraform configuration (`config.auto.tfvars.advanced.sample`) to reflect the correct range and added a clarifying note about the API enforcement.

**Test Updates:**

* Adjusted unit tests in `TapConfigurationValidationTests.cs` to test the new lower (59) and upper (481) boundary failures, and updated expected error messages to match the new range.
* Updated a valid test case to use the new minimum allowed value (60) instead of the previous lower value (30).