### PR TITLE
feat: add commit message prefix for GitHub Actions dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "deps(ci)"


### PR DESCRIPTION
This pull request makes a small configuration update to Dependabot. The change adds a commit message prefix for automated dependency update PRs, making them easier to identify in the commit history.