### PR TITLE
feat: add help link icon

### DIFF
--- a/src/MyWorkID.Client/src/assets/css/main.css
+++ b/src/MyWorkID.Client/src/assets/css/main.css
@@ -415,6 +415,19 @@ body {
     max-height: 1.8rem;
   }
 }
+.header__buttons__help-link {
+  height: 36px;
+  width: 36px;
+  align-self: center;
+  cursor: pointer;
+  margin-right: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+.header__buttons__help-link__icon {
+  transform: translateY(4px);
+}
 .no-select {
   user-select: none;
   -moz-user-select: none;

--- a/src/MyWorkID.Client/src/assets/svg/help-circle.svg
+++ b/src/MyWorkID.Client/src/assets/svg/help-circle.svg
@@ -1,0 +1,11 @@
+<svg width="38" height="38" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paint0_linear_help_2123_2054" x1="12" y1="2" x2="12" y2="22" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5CBBFF"></stop>
+      <stop offset="1" stop-color="#0072C6"></stop>
+    </linearGradient>
+  </defs>
+  <circle cx="12" cy="12" r="10" stroke="url(#paint0_linear_help_2123_2054)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" stroke="url(#paint0_linear_help_2123_2054)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="12" y1="17" x2="12.01" y2="17" stroke="url(#paint0_linear_help_2123_2054)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/MyWorkID.Client/src/components/header.tsx
+++ b/src/MyWorkID.Client/src/components/header.tsx
@@ -2,8 +2,11 @@ import { useTheme } from "./use-theme";
 import HeaderLogoSvg from "../assets/svg/header-logo.svg";
 import DarkModeSvg from "../assets/svg/dark-mode-toggle.svg";
 import LogOutSvg from "../assets/svg/log-out.svg";
+import HelpCircleSvg from "../assets/svg/help-circle.svg";
 import { useMsal } from "@azure/msal-react";
 import { useToast } from "@/hooks/use-toast";
+import { useEffect, useState } from "react";
+import { getFrontendOptions } from "@/services/frontend-options-service";
 
 enum ColorTheme {
   Light = "light",
@@ -15,6 +18,31 @@ export const Header = () => {
   const { instance } = useMsal();
   const { setTheme } = useTheme();
   const { toastError } = useToast();
+  const [helpUrl, setHelpUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getFrontendOptions()
+      .then((options) => {
+        if (cancelled) return;
+        const url = options.helpUrl?.trim();
+        if (!url) return;
+        try {
+          const parsed = new URL(url);
+          if (parsed.protocol !== "https:") return;
+          setHelpUrl(parsed.href);
+        } catch {
+          console.error("Invalid help URL:", url);
+        }
+      })
+      .catch(() => {
+        // ignore - header should still render
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const setColorTheme = () => {
     if ((localStorage.getItem(STORAGEKEY) as Theme) === "dark") {
       setTheme(ColorTheme.Light);
@@ -35,6 +63,18 @@ export const Header = () => {
         <span className="header__title__text-ID">ID</span>
       </div>
       <div className="header__buttons">
+        {helpUrl && (
+          <a
+            className="header__buttons__help-link"
+            href={helpUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Help"
+            title="Help"
+          >
+            <img src={HelpCircleSvg} alt="Help" className="header__buttons__help-link__icon" />
+          </a>
+        )}
         <button
           className="header__buttons__logout-button"
           onClick={handleLogoutRedirect}

--- a/src/MyWorkID.Client/src/components/header.tsx
+++ b/src/MyWorkID.Client/src/components/header.tsx
@@ -24,12 +24,18 @@ export const Header = () => {
     let cancelled = false;
     void getFrontendOptions()
       .then((options) => {
-        if (cancelled) return;
+        if (cancelled) {
+          return;
+        }
         const url = options.helpUrl?.trim();
-        if (!url) return;
+        if (!url) {
+          return;
+        }
         try {
           const parsed = new URL(url);
-          if (parsed.protocol !== "https:") return;
+          if (parsed.protocol !== "https:") {
+            return;
+          }
           setHelpUrl(parsed.href);
         } catch {
           console.error("Invalid help URL:", url);

--- a/src/MyWorkID.Client/src/services/frontend-options-service.ts
+++ b/src/MyWorkID.Client/src/services/frontend-options-service.ts
@@ -1,20 +1,22 @@
 import axios from "axios";
 import { TFrontendOptions } from "../types";
 
-let frontendOptionsCache: TFrontendOptions | undefined = undefined;
+let frontendOptionsPromise: Promise<TFrontendOptions> | undefined = undefined;
 
-export const getFrontendOptions = async () => {
-  if (frontendOptionsCache) {
-    return frontendOptionsCache;
+export const getFrontendOptions = (): Promise<TFrontendOptions> => {
+  if (frontendOptionsPromise) {
+    return frontendOptionsPromise;
   }
 
   const apiUrl: string = `${window.location.protocol}//${window.location.host}/api/config/frontend`;
-  const frontendOptionsResponse = await axios.get<TFrontendOptions>(apiUrl);
-  frontendOptionsCache = frontendOptionsResponse.data;
-  if (!frontendOptionsCache) {
-    throw new Error("Frontend options not found");
-  }
-  return frontendOptionsCache;
+  frontendOptionsPromise = axios.get<TFrontendOptions>(apiUrl).then((response) => {
+    if (!response.data) {
+      throw new Error("Frontend options not found");
+    }
+    return response.data;
+  });
+
+  return frontendOptionsPromise;
 };
 
 export const loadCustomCss = (customCssUrl?: string) => {

--- a/src/MyWorkID.Client/src/services/frontend-options-service.ts
+++ b/src/MyWorkID.Client/src/services/frontend-options-service.ts
@@ -9,12 +9,18 @@ export const getFrontendOptions = (): Promise<TFrontendOptions> => {
   }
 
   const apiUrl: string = `${window.location.protocol}//${window.location.host}/api/config/frontend`;
-  frontendOptionsPromise = axios.get<TFrontendOptions>(apiUrl).then((response) => {
-    if (!response.data) {
-      throw new Error("Frontend options not found");
-    }
-    return response.data;
-  });
+  frontendOptionsPromise = axios
+    .get<TFrontendOptions>(apiUrl)
+    .then((response) => {
+      if (!response.data) {
+        throw new Error("Frontend options not found");
+      }
+      return response.data;
+    })
+    .catch((error) => {
+      frontendOptionsPromise = undefined;
+      throw error;
+    });
 
   return frontendOptionsPromise;
 };

--- a/src/MyWorkID.Client/src/types.ts
+++ b/src/MyWorkID.Client/src/types.ts
@@ -15,6 +15,7 @@ export type TFrontendOptions = {
   customCssUrl?: string;
   appTitle?: string;
   faviconUrl?: string;
+  helpUrl?: string;
 };
 
 export type TFunctionResult<T = undefined> = {

--- a/src/MyWorkID.Server/Options/FrontendOptions.cs
+++ b/src/MyWorkID.Server/Options/FrontendOptions.cs
@@ -41,5 +41,10 @@ namespace MyWorkID.Server.Options
         /// URL to the favicon icon.
         /// </summary>
         public string? FaviconUrl { get; set; }
+
+        /// <summary>
+        /// Optional URL to a help page. When set, a help icon is shown in the header that links to this URL.
+        /// </summary>
+        public string? HelpUrl { get; set; }
     }
 }

--- a/src/MyWorkID.Server/appsettings-dummy.json
+++ b/src/MyWorkID.Server/appsettings-dummy.json
@@ -25,7 +25,8 @@
     "backendClientId": "<backendClientId>",
     "customCssUrl": "<optional public url to custom css>",
     "appTitle": "<optional appTitle>",
-    "faviconUrl": "<optional faviconUrl>"
+    "faviconUrl": "<optional faviconUrl>",
+    "helpUrl": "<optional public url to a help page>"
   },
   "VerifiedId": {
     "DecentralizedIdentifier": "<didId Secret of your tenant>",

--- a/terraform/config.auto.tfvars.advanced.sample
+++ b/terraform/config.auto.tfvars.advanced.sample
@@ -78,6 +78,9 @@ app_title = null
 # Optional URL to the favicon icon. Must be a publicly accessible HTTPS URL
 favicon_url = null
 
+# Optional URL to a help page. When set, a help icon is shown in the header that links to this URL. Must be a publicly accessible HTTPS URL
+help_url = null
+
 # ------- Tap Settings -------
 
 # Optional override for the TAP lifetime (minutes). Must be between 60 and 480 when set.

--- a/terraform/config.auto.tfvars.sample
+++ b/terraform/config.auto.tfvars.sample
@@ -14,3 +14,4 @@ allow_credential_operations_for_privileged_users = false # Allow credential oper
 custom_css_url = "REPLACE_WITH_CUSTOM_CSS_URL" # URL to a custom CSS file for branding the MyWorkID app. Leave empty to use the default styling.
 favicon_url = "REPLACE_WITH_FAVICON_URL" # URL to a favicon image for the MyWorkID app. Leave empty to use the default favicon.
 app_title = "REPLACE_WITH_APP_TITLE" # The title displayed in the browser tab and app header. Set to customize the application name.
+help_url = "REPLACE_WITH_HELP_URL" # URL to a help page. When set, a help icon is shown in the header that links to this URL. Leave empty to hide the help icon.

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -22,6 +22,7 @@ locals {
   custom_css_url                                   = var.custom_css_url
   app_title                                        = var.app_title
   favicon_url                                      = var.favicon_url
+  help_url                                         = var.help_url
   enable_auto_update                               = var.enable_auto_update
   allow_credential_operations_for_privileged_users = var.allow_credential_operations_for_privileged_users
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,6 +81,7 @@ resource "azurerm_linux_web_app" "backend" {
     Frontend__CustomCssUrl                     = local.custom_css_url
     Frontend__AppTitle                         = local.app_title
     Frontend__FaviconUrl                       = local.favicon_url
+    Frontend__HelpUrl                          = local.help_url
     WEBSITE_RUN_FROM_PACKAGE                   = local.enable_auto_update ? local.latest_binaries_url : "1"
     APPLICATIONINSIGHTS_CONNECTION_STRING      = azurerm_application_insights.backend.connection_string
     ApplicationInsightsAgent_EXTENSION_VERSION = "~3"          #https://learn.microsoft.com/en-us/azure/azure-monitor/app/azure-web-apps-net-core?tabs=Windows%2Cwindows#application-settings-definitions

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -129,6 +129,13 @@ variable "favicon_url" {
   nullable    = true
 }
 
+variable "help_url" {
+  type        = string
+  description = "Optional URL to a help page. When set, a help icon is shown in the header that links to this URL. Must be a publicly accessible HTTPS URL"
+  default     = null
+  nullable    = true
+}
+
 # Tap settings
 variable "tap_lifetime_in_minutes" {
   type        = number

--- a/tests/MyWorkID.Server.IntegrationTests/Features/Configuration/FrontendConfigTests.cs
+++ b/tests/MyWorkID.Server.IntegrationTests/Features/Configuration/FrontendConfigTests.cs
@@ -33,7 +33,7 @@ namespace MyWorkID.Server.IntegrationTests.Features.Configuration
         {
             var client = _testApplicationFactory
                 .WithWebHostBuilder(builder =>
-                    builder.ConfigureAppConfiguration(config =>
+                    builder.ConfigureAppConfiguration((_, config) =>
                         config.AddInMemoryCollection(new Dictionary<string, string?>
                         {
                             ["Frontend:HelpUrl"] = "https://example.com/help"

--- a/tests/MyWorkID.Server.IntegrationTests/Features/Configuration/FrontendConfigTests.cs
+++ b/tests/MyWorkID.Server.IntegrationTests/Features/Configuration/FrontendConfigTests.cs
@@ -1,5 +1,7 @@
 ﻿using MyWorkID.Server.Options;
 using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System.Net;
@@ -23,6 +25,25 @@ namespace MyWorkID.Server.IntegrationTests.Features.Configuration
             frontendAppSettings.BackendClientId.Should().Be(frontendOptions!.BackendClientId);
             frontendAppSettings.FrontendClientId.Should().Be(frontendOptions.FrontendClientId);
             frontendAppSettings.TenantId.Should().Be(frontendOptions.TenantId);
+            frontendOptions.HelpUrl.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GetConfig_WithHelpUrl_ReturnsHelpUrlInResponse()
+        {
+            var client = _testApplicationFactory
+                .WithWebHostBuilder(builder =>
+                    builder.ConfigureAppConfiguration(config =>
+                        config.AddInMemoryCollection(new Dictionary<string, string?>
+                        {
+                            ["Frontend:HelpUrl"] = "https://example.com/help"
+                        })))
+                .CreateDefaultClient();
+            var response = await client.GetAsync(_baseUrl);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var frontendOptions = await response.Content.ReadFromJsonAsync<FrontendOptions>();
+            frontendOptions.Should().NotBeNull();
+            frontendOptions!.HelpUrl.Should().Be("https://example.com/help");
         }
     }
 }

--- a/tests/MyWorkID.Server.UnitTests/Configuration/FrontendConfigurationValidationTests.cs
+++ b/tests/MyWorkID.Server.UnitTests/Configuration/FrontendConfigurationValidationTests.cs
@@ -95,6 +95,16 @@ namespace MyWorkID.Server.UnitTests.Configuration
                     ),
                     null,
                     null
+                },
+                {
+                    TestConfigurationSection.Create(
+                        ("Frontend:FrontendClientId", Guid.NewGuid().ToString()),
+                        ("Frontend:TenantId", Guid.NewGuid().ToString()),
+                        ("Frontend:BackendClientId", Guid.NewGuid().ToString()),
+                        ("Frontend:HelpUrl", "https://example.com/help")
+                    ),
+                    null,
+                    null
                 }
             };
         }


### PR DESCRIPTION
close #141 

This pull request adds support for an optional help page link in the application header. When a valid HTTPS help URL is configured, a help icon appears in the header, linking users to the specified help page. The feature is configurable via both the backend options and Terraform deployment variables, ensuring flexibility for different environments.

**Frontend changes:**
- Added a help icon (`HelpCircleSvg`) to the header, which appears if a valid `helpUrl` is provided, and links to the configured help page in a new tab. The URL is validated to ensure it uses HTTPS. (`src/MyWorkID.Client/src/components/header.tsx` [[1]](diffhunk://#diff-fd6214705ad0e847013e7fd7ef638240a862316ce81d39c68e882b3511b39c76R5-R9) [[2]](diffhunk://#diff-fd6214705ad0e847013e7fd7ef638240a862316ce81d39c68e882b3511b39c76R21-R45) [[3]](diffhunk://#diff-fd6214705ad0e847013e7fd7ef638240a862316ce81d39c68e882b3511b39c76R66-R77)
- Added new CSS styles for the help icon and link in the header. (`src/MyWorkID.Client/src/assets/css/main.css` [src/MyWorkID.Client/src/assets/css/main.cssR418-R430](diffhunk://#diff-1fff02bf02f8c5dd181644027b2222910bfbede4450e23db9dacdb6bb50b7850R418-R430))
- Extended the frontend options type to include an optional `helpUrl` property. (`src/MyWorkID.Client/src/types.ts` [src/MyWorkID.Client/src/types.tsR18](diffhunk://#diff-b3b25a9d386c7077ec7c2c299b40cd0500317f7c163081375218104322476508R18))

**Backend and configuration changes:**
- Added an optional `HelpUrl` property to the backend `FrontendOptions` class, with documentation. (`src/MyWorkID.Server/Options/FrontendOptions.cs` [src/MyWorkID.Server/Options/FrontendOptions.csR44-R48](diffhunk://#diff-30faa1a0ad7299e668a5ce49243c3c3bed7d4e6f729a3d3b364eafaa6cbd2b46R44-R48))
- Updated the dummy app settings to include a `helpUrl` example. (`src/MyWorkID.Server/appsettings-dummy.json` [src/MyWorkID.Server/appsettings-dummy.jsonL28-R29](diffhunk://#diff-20636faaa76103449abeb06203c7f4d3de416fe631628dd087395a672e8a6a13L28-R29))

**Terraform deployment changes:**
- Added a new `help_url` variable, included it in local values and the web app environment variables, and updated sample configuration files with documentation and examples. (`terraform/variables.tf` [[1]](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R132-R138) `terraform/locals.tf` [[2]](diffhunk://#diff-1e88310e1535b90c37b1069d56c203a3a4f406bd3a8b17d701a9b65c443e4193R25) `terraform/main.tf` [[3]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R84) `terraform/config.auto.tfvars.advanced.sample` [[4]](diffhunk://#diff-592fbb792a908d4f638759b84e57a0610767d63d4dd1d4a5afb814a700e1dd94R81-R83) `terraform/config.auto.tfvars.sample` [[5]](diffhunk://#diff-8fc5e6fe1bf6d551804c00e135ce5f804da6f48bb4f333d3f7bb4235cceebc3bR17)