### PR TITLE
fix: fix card flickering and add toast copy button

### DIFF
--- a/src/MyWorkID.Client/src/components/function-plane/function-plane.tsx
+++ b/src/MyWorkID.Client/src/components/function-plane/function-plane.tsx
@@ -86,7 +86,10 @@ const FunctionPlane = () => {
     (profile.riskLevel === RiskLevel.High ||
       profile.riskLevel === RiskLevel.Medium);
 
-  const closePanel = () => setActivePanel(null);
+  const closePanel = () => {
+    setActivePanel(null);
+    setRedirectAction(undefined);
+  };
 
   return (
     <main className="app-main">

--- a/src/MyWorkID.Client/src/components/ui/toaster.tsx
+++ b/src/MyWorkID.Client/src/components/ui/toaster.tsx
@@ -1,4 +1,6 @@
-import { useToast } from "@/hooks/use-toast"
+import * as React from "react";
+import { CheckIcon, CopyIcon } from "@radix-ui/react-icons";
+import { useToast } from "@/hooks/use-toast";
 import {
   Toast,
   ToastClose,
@@ -6,14 +8,51 @@ import {
   ToastProvider,
   ToastTitle,
   ToastViewport,
-} from "@/components/ui/toast"
+} from "@/components/ui/toast";
 
-export function Toaster() {
-  const { toasts } = useToast()
+function CorrelationIdRow({
+  correlationId,
+}: Readonly<{ correlationId: string }>) {
+  const [copied, setCopied] = React.useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(correlationId);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
 
   return (
-    <ToastProvider>
-      {toasts.map(function ({ id, title, description, action, correlationId, ...props }) {
+    <ToastDescription className="text-xs opacity-70 mt-1 flex items-center gap-1">
+      Correlation ID: {correlationId}
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="ml-1 opacity-70 transition-opacity hover:opacity-100"
+        aria-label="Copy correlation ID"
+      >
+        {copied ? (
+          <CheckIcon className="h-5 w-5" />
+        ) : (
+          <CopyIcon className="h-5 w-5" />
+        )}
+      </button>
+    </ToastDescription>
+  );
+}
+
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider duration={8000}>
+      {toasts.map(function ({
+        id,
+        title,
+        description,
+        action,
+        correlationId,
+        ...props
+      }) {
         return (
           <Toast key={id} {...props}>
             <div className="grid gap-1">
@@ -22,17 +61,15 @@ export function Toaster() {
                 <ToastDescription>{description}</ToastDescription>
               )}
               {correlationId && (
-                <ToastDescription className="text-xs opacity-70 mt-1">
-                  Correlation ID: {correlationId}
-                </ToastDescription>
+                <CorrelationIdRow correlationId={correlationId} />
               )}
             </div>
             {action}
             <ToastClose />
           </Toast>
-        )
+        );
       })}
       <ToastViewport />
     </ToastProvider>
-  )
+  );
 }

--- a/src/MyWorkID.Client/src/components/ui/toaster.tsx
+++ b/src/MyWorkID.Client/src/components/ui/toaster.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/toast";
 
 const COPIED_INFO_TOAST_DISMISSAL_TIME_MILLISECONDS = 2000;
+const TOAST_DISPLAY_TIME_MILLISECONDS = 8000;
 
 const CorrelationIdRow = ({
   correlationId,
@@ -67,7 +68,7 @@ export const Toaster = () => {
   const { toasts } = useToast();
 
   return (
-    <ToastProvider duration={8000}>
+    <ToastProvider duration={TOAST_DISPLAY_TIME_MILLISECONDS}>
       {toasts.map(
         ({ id, title, description, action, correlationId, ...props }) => (
           <Toast key={id} {...props}>

--- a/src/MyWorkID.Client/src/components/ui/toaster.tsx
+++ b/src/MyWorkID.Client/src/components/ui/toaster.tsx
@@ -10,6 +10,8 @@ import {
   ToastViewport,
 } from "@/components/ui/toast";
 
+const COPIED_INFO_TOAST_DISMISSAL_TIME_MILLISECONDS = 2000;
+
 function CorrelationIdRow({
   correlationId,
 }: Readonly<{ correlationId: string }>) {
@@ -35,7 +37,7 @@ function CorrelationIdRow({
         copiedTimerRef.current = window.setTimeout(() => {
           setCopied(false);
           copiedTimerRef.current = undefined;
-        }, 2000);
+        }, COPIED_INFO_TOAST_DISMISSAL_TIME_MILLISECONDS);
       })
       .catch((error) => {
         console.debug("Failed to copy correlation ID to clipboard", error);

--- a/src/MyWorkID.Client/src/components/ui/toaster.tsx
+++ b/src/MyWorkID.Client/src/components/ui/toaster.tsx
@@ -14,11 +14,32 @@ function CorrelationIdRow({
   correlationId,
 }: Readonly<{ correlationId: string }>) {
   const [copied, setCopied] = React.useState(false);
+  const copiedTimerRef = React.useRef<number | undefined>(undefined);
+
+  React.useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current !== undefined) {
+        window.clearTimeout(copiedTimerRef.current);
+      }
+    };
+  }, []);
 
   function handleCopy() {
-    navigator.clipboard.writeText(correlationId);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    navigator.clipboard
+      .writeText(correlationId)
+      .then(() => {
+        setCopied(true);
+        if (copiedTimerRef.current !== undefined) {
+          window.clearTimeout(copiedTimerRef.current);
+        }
+        copiedTimerRef.current = window.setTimeout(() => {
+          setCopied(false);
+          copiedTimerRef.current = undefined;
+        }, 2000);
+      })
+      .catch((error) => {
+        console.debug("Failed to copy correlation ID to clipboard", error);
+      });
   }
 
   return (

--- a/src/MyWorkID.Client/src/components/ui/toaster.tsx
+++ b/src/MyWorkID.Client/src/components/ui/toaster.tsx
@@ -12,9 +12,9 @@ import {
 
 const COPIED_INFO_TOAST_DISMISSAL_TIME_MILLISECONDS = 2000;
 
-function CorrelationIdRow({
+const CorrelationIdRow = ({
   correlationId,
-}: Readonly<{ correlationId: string }>) {
+}: Readonly<{ correlationId: string }>) => {
   const [copied, setCopied] = React.useState(false);
   const copiedTimerRef = React.useRef<number | undefined>(undefined);
 
@@ -26,7 +26,7 @@ function CorrelationIdRow({
     };
   }, []);
 
-  function handleCopy() {
+  const handleCopy = () => {
     navigator.clipboard
       .writeText(correlationId)
       .then(() => {
@@ -42,7 +42,7 @@ function CorrelationIdRow({
       .catch((error) => {
         console.debug("Failed to copy correlation ID to clipboard", error);
       });
-  }
+  };
 
   return (
     <ToastDescription className="text-xs opacity-70 mt-1 flex items-center gap-1">
@@ -61,22 +61,15 @@ function CorrelationIdRow({
       </button>
     </ToastDescription>
   );
-}
+};
 
-export function Toaster() {
+export const Toaster = () => {
   const { toasts } = useToast();
 
   return (
     <ToastProvider duration={8000}>
-      {toasts.map(function ({
-        id,
-        title,
-        description,
-        action,
-        correlationId,
-        ...props
-      }) {
-        return (
+      {toasts.map(
+        ({ id, title, description, action, correlationId, ...props }) => (
           <Toast key={id} {...props}>
             <div className="grid gap-1">
               {title && <ToastTitle>{title}</ToastTitle>}
@@ -90,9 +83,9 @@ export function Toaster() {
             {action}
             <ToastClose />
           </Toast>
-        );
-      })}
+        ),
+      )}
       <ToastViewport />
     </ToastProvider>
   );
-}
+};


### PR DESCRIPTION
This pull request enhances the user experience of the toast notifications and improves state management in the `FunctionPlane` component. The most important changes are:

**UI/UX Improvements to Toast Notifications:**

* Added a new `CorrelationIdRow` component to the `Toaster` that displays the correlation ID with a copy-to-clipboard button and visual feedback when copied. This replaces the plain text correlation ID previously shown in toast notifications. [[1]](diffhunk://#diff-cf219a2332d891db0b795399a474966ebb0dbad8af686d1fba1947297e4f87fdL1-R55) [[2]](diffhunk://#diff-cf219a2332d891db0b795399a474966ebb0dbad8af686d1fba1947297e4f87fdL25-R74)
* Updated the `ToastProvider` to set a default duration of 8000ms for toasts, ensuring consistent display timing.

**State Management Fixes:**

* Modified the `closePanel` function in `FunctionPlane` to also reset `redirectAction` to `undefined` when closing the panel, preventing unintended redirects after the panel is closed.