### PR TITLE
feat: version number in frontend

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -7,6 +7,11 @@ concurrency:
 
 on:
   workflow_dispatch:
+    inputs:
+      appVersion:
+        description: "Version shown in app footer"
+        required: false
+        type: string
   push:
     paths:
       - "src/**"
@@ -23,23 +28,13 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      APP_VERSION: ${{ github.event.inputs.appVersion || github.ref_name }}
     defaults:
       run:
         working-directory: ${{env.PROJECT_ROOT_DIRECTORY}}
     steps:
       - uses: actions/checkout@v7
-        with:
-          # used for Vite to resolve the correct version of the build
-          fetch-depth: 0
-
-      - name: Compute app version
-        shell: pwsh
-        run: |
-          $tag = git describe --tags --abbrev=0
-          $refName = "${{ github.ref_name }}"
-          $version = if ($refName -eq "main") { $tag } else { "$tag ($refName)" }
-          "APP_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          Write-Host "Building with APP_VERSION=$version"
 
       # Load NuGetCache
       - name: Restore NuGet Cache

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -32,6 +32,15 @@ jobs:
           # used for Vite to resolve the correct version of the build
           fetch-depth: 0
 
+      - name: Compute app version
+        shell: pwsh
+        run: |
+          $tag = git describe --tags --abbrev=0
+          $refName = "${{ github.ref_name }}"
+          $version = if ($refName -eq "main") { $tag } else { "$tag ($refName)" }
+          "APP_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Building with APP_VERSION=$version"
+
       # Load NuGetCache
       - name: Restore NuGet Cache
         uses: actions/cache@v6

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       appVersion:
-        description: "Version shown in app footer"
+        description: "Version shown in app footer - leave field empty to use current branch name"
         required: false
         type: string
   push:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -28,6 +28,9 @@ jobs:
         working-directory: ${{env.PROJECT_ROOT_DIRECTORY}}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # used for Vite to resolve the correct version of the build
+          fetch-depth: 0
 
       # Load NuGetCache
       - name: Restore NuGet Cache

--- a/src/MyWorkID.Client/src/assets/css/main.css
+++ b/src/MyWorkID.Client/src/assets/css/main.css
@@ -985,6 +985,11 @@
   color: var(--text-secondary);
 }
 
+.app-footer__version {
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
 .app-footer__logo-link {
   display: inline-flex;
   align-items: center;

--- a/src/MyWorkID.Client/src/components/footer.tsx
+++ b/src/MyWorkID.Client/src/components/footer.tsx
@@ -23,6 +23,7 @@ export const Footer = () => {
           alt="glueckkanja"
         />
       </a>
+      <span className="app-footer__version">{__APP_VERSION__}</span>
     </footer>
   );
 };

--- a/src/MyWorkID.Client/src/vite-env.d.ts
+++ b/src/MyWorkID.Client/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/src/MyWorkID.Client/vite.config.ts
+++ b/src/MyWorkID.Client/vite.config.ts
@@ -52,34 +52,55 @@ const targetWebSocket = target
   .replace("http://", "wss://");
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      // "@": fileURLToPath(new URL("./src", import.meta.url)),
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ command }) => {
+  let appVersion: string;
+  if (command === "serve") {
+    appVersion = "development";
+  } else {
+    try {
+      appVersion = child_process
+        .execSync("git describe --tags --abbrev=0", {
+          stdio: ["ignore", "pipe", "ignore"],
+        })
+        .toString()
+        .trim();
+    } catch {
+      appVersion = "unknown";
+    }
+  }
+
+  return {
+    plugins: [react()],
+    define: {
+      __APP_VERSION__: JSON.stringify(appVersion),
     },
-  },
-  server: {
-    proxy: {
-      "/api": {
-        target,
-        secure: false,
-      },
-      "/hubs/verifiedId/negotiate": {
-        target: target,
-        secure: false,
-      },
-      "/hubs": {
-        target: targetWebSocket,
-        ws: true,
-        secure: false,
+    resolve: {
+      alias: {
+        // "@": fileURLToPath(new URL("./src", import.meta.url)),
+        "@": path.resolve(__dirname, "./src"),
       },
     },
-    port: 5173,
-    https: {
-      key: fs.readFileSync(keyFilePath),
-      cert: fs.readFileSync(certFilePath),
+    server: {
+      proxy: {
+        "/api": {
+          target,
+          secure: false,
+        },
+        "/hubs/verifiedId/negotiate": {
+          target: target,
+          secure: false,
+        },
+        "/hubs": {
+          target: targetWebSocket,
+          ws: true,
+          secure: false,
+        },
+      },
+      port: 5173,
+      https: {
+        key: fs.readFileSync(keyFilePath),
+        cert: fs.readFileSync(certFilePath),
+      },
     },
-  },
+  };
 });

--- a/src/MyWorkID.Client/vite.config.ts
+++ b/src/MyWorkID.Client/vite.config.ts
@@ -52,55 +52,37 @@ const targetWebSocket = target
   .replace("http://", "wss://");
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => {
-  let appVersion: string;
-  if (command === "serve") {
-    appVersion = "development";
-  } else {
-    try {
-      appVersion = child_process
-        .execSync("git describe --tags --abbrev=0", {
-          stdio: ["ignore", "pipe", "ignore"],
-        })
-        .toString()
-        .trim();
-    } catch {
-      appVersion = "unknown";
-    }
-  }
-
-  return {
-    plugins: [react()],
-    define: {
-      __APP_VERSION__: JSON.stringify(appVersion),
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.APP_VERSION ?? "development"),
+  },
+  resolve: {
+    alias: {
+      // "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "@": path.resolve(__dirname, "./src"),
     },
-    resolve: {
-      alias: {
-        // "@": fileURLToPath(new URL("./src", import.meta.url)),
-        "@": path.resolve(__dirname, "./src"),
+  },
+  server: {
+    proxy: {
+      "/api": {
+        target,
+        secure: false,
+      },
+      "/hubs/verifiedId/negotiate": {
+        target: target,
+        secure: false,
+      },
+      "/hubs": {
+        target: targetWebSocket,
+        ws: true,
+        secure: false,
       },
     },
-    server: {
-      proxy: {
-        "/api": {
-          target,
-          secure: false,
-        },
-        "/hubs/verifiedId/negotiate": {
-          target: target,
-          secure: false,
-        },
-        "/hubs": {
-          target: targetWebSocket,
-          ws: true,
-          secure: false,
-        },
-      },
-      port: 5173,
-      https: {
-        key: fs.readFileSync(keyFilePath),
-        cert: fs.readFileSync(certFilePath),
-      },
+    port: 5173,
+    https: {
+      key: fs.readFileSync(keyFilePath),
+      cert: fs.readFileSync(certFilePath),
     },
-  };
+  },
 });


### PR DESCRIPTION
This pull request adds support for displaying the application version in the app footer, making it easier to identify which build is currently running. The version can now be set dynamically during the build process, either via a workflow input or using the current branch name as a fallback. The most important changes are grouped below.

**CI/CD and Build Process:**

* [`.github/workflows/build-binaries.yml`](diffhunk://#diff-e0c5149ab771083cacddbeaf3336656118f582f6311228e0b8652c3209a7dd2eR10-R14): Added an optional `appVersion` input to the workflow, and set the `APP_VERSION` environment variable to either the provided input or the current branch name. [[1]](diffhunk://#diff-e0c5149ab771083cacddbeaf3336656118f582f6311228e0b8652c3209a7dd2eR10-R14) [[2]](diffhunk://#diff-e0c5149ab771083cacddbeaf3336656118f582f6311228e0b8652c3209a7dd2eR31-R32)

**Frontend Integration:**

* [`src/MyWorkID.Client/vite.config.ts`](diffhunk://#diff-f9598b4129777a089284bac311416d0003ad1efe412d9617ba34387b6496b69bR57-R59): Defined a global `__APP_VERSION__` constant at build time, defaulting to the value of `APP_VERSION` or "development" if not set.
* [`src/MyWorkID.Client/src/components/footer.tsx`](diffhunk://#diff-6a140fa9dc2b23615506c7944dce5b5a80fc15c5a35fc19993818fa72297c59fR26): Displayed the application version in the footer using the new `__APP_VERSION__` constant.
* [`src/MyWorkID.Client/src/assets/css/main.css`](diffhunk://#diff-1fff02bf02f8c5dd181644027b2222910bfbede4450e23db9dacdb6bb50b7850R988-R992): Added styling for the footer version display to ensure it is visually distinct and uses tabular numbers.

closes #150 

As shown in #157 the plan is to provide the version number during binaries-reusable workflow call. Manual binary builds will be possible with the same workflow but then it is possible for dev purposes to provide the version number manually.