### PR TITLE
feat: add system related dark/light theme adjustment

### DIFF
--- a/src/MyWorkID.Client/src/app.tsx
+++ b/src/MyWorkID.Client/src/app.tsx
@@ -22,7 +22,7 @@ export const App = () => {
   }, []);
 
   return (
-    <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
+    <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
       <div className="app-shell">
         <Header />
         <FunctionPlane />

--- a/src/MyWorkID.Client/src/components/header.tsx
+++ b/src/MyWorkID.Client/src/components/header.tsx
@@ -16,17 +16,13 @@ enum ColorTheme {
   Dark = "dark",
 }
 
-const STORAGE_KEY = "vite-ui-theme";
-
 export const Header = () => {
   const { instance } = useMsal();
-  const { setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   const { toastError } = useToast();
   const [helpUrl, setHelpUrl] = useState<string | undefined>(undefined);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [darkMode, setDarkMode] = useState(
-    () => (localStorage.getItem(STORAGE_KEY) as ColorTheme) === ColorTheme.Dark,
-  );
+  const darkMode = resolvedTheme === ColorTheme.Dark;
 
   useEffect(() => {
     let cancelled = false;
@@ -58,7 +54,6 @@ export const Header = () => {
   }, []);
 
   const handleDarkModeToggle = (enabled: boolean) => {
-    setDarkMode(enabled);
     setTheme(enabled ? ColorTheme.Dark : ColorTheme.Light);
   };
 

--- a/src/MyWorkID.Client/src/components/theme-provider.tsx
+++ b/src/MyWorkID.Client/src/components/theme-provider.tsx
@@ -17,8 +17,12 @@ type ThemeProviderState = {
 
 const SYSTEM_DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)"
 
-const getSystemTheme = (): ResolvedTheme =>
-  window.matchMedia(SYSTEM_DARK_MEDIA_QUERY).matches ? "dark" : "light"
+const getSystemTheme = (): ResolvedTheme => {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return "light"
+  }
+  return window.matchMedia(SYSTEM_DARK_MEDIA_QUERY).matches ? "dark" : "light"
+}
 
 const initialState: ThemeProviderState = {
   theme: "system",
@@ -42,6 +46,9 @@ export function ThemeProvider({
   )
 
   useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return
+    }
     const mediaQuery = window.matchMedia(SYSTEM_DARK_MEDIA_QUERY)
     const handleChange = (event: MediaQueryListEvent) => {
       setSystemTheme(event.matches ? "dark" : "light")

--- a/src/MyWorkID.Client/src/components/theme-provider.tsx
+++ b/src/MyWorkID.Client/src/components/theme-provider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useEffect, useMemo, useState } from "react"
 
 type Theme = "dark" | "light" | "system"
+type ResolvedTheme = "dark" | "light"
 
 type ThemeProviderProps = {
   children: React.ReactNode
@@ -10,12 +11,18 @@ type ThemeProviderProps = {
 
 type ThemeProviderState = {
   theme: Theme
+  resolvedTheme: ResolvedTheme
   setTheme: (theme: Theme) => void
 }
 
+const SYSTEM_DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)"
+
+const getSystemTheme = (): ResolvedTheme =>
+  window.matchMedia(SYSTEM_DARK_MEDIA_QUERY).matches ? "dark" : "light"
 
 const initialState: ThemeProviderState = {
   theme: "system",
+  resolvedTheme: "light",
   setTheme: () => null,
 }
 
@@ -28,34 +35,42 @@ export function ThemeProvider({
   ...props
 }: Readonly<ThemeProviderProps>) {
   const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+    () => (sessionStorage.getItem(storageKey) as Theme) || defaultTheme
+  )
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
+    getSystemTheme()
   )
 
   useEffect(() => {
-    const root = window.document.documentElement
-
-    root.classList.remove("light", "dark")
-
-    if (theme === "system") {
-      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-        .matches
-        ? "dark"
-        : "light"
-
-      root.classList.add(systemTheme)
-      return
+    const mediaQuery = window.matchMedia(SYSTEM_DARK_MEDIA_QUERY)
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? "dark" : "light")
     }
+    mediaQuery.addEventListener("change", handleChange)
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange)
+    }
+  }, [])
 
-    root.classList.add(theme)
-  }, [theme])
+  const resolvedTheme: ResolvedTheme = theme === "system" ? systemTheme : theme
 
-  const value = useMemo(() => ({
-    theme,
-    setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme);
-      setTheme(theme);
-    },
-  }), [theme, storageKey, setTheme]);
+  useEffect(() => {
+    const root = window.document.documentElement
+    root.classList.remove("light", "dark")
+    root.classList.add(resolvedTheme)
+  }, [resolvedTheme])
+
+  const value = useMemo(
+    () => ({
+      theme,
+      resolvedTheme,
+      setTheme: (nextTheme: Theme) => {
+        sessionStorage.setItem(storageKey, nextTheme)
+        setTheme(nextTheme)
+      },
+    }),
+    [theme, resolvedTheme, storageKey]
+  )
 
   return (
     <ThemeProviderContext.Provider {...props} value={value}>

--- a/src/MyWorkID.Client/src/components/theme-provider.tsx
+++ b/src/MyWorkID.Client/src/components/theme-provider.tsx
@@ -1,36 +1,43 @@
-import { createContext, useEffect, useMemo, useState } from "react"
+import { createContext, useEffect, useMemo, useState } from "react";
 
-type Theme = "dark" | "light" | "system"
-type ResolvedTheme = "dark" | "light"
+type Theme = "dark" | "light" | "system";
+type ResolvedTheme = "dark" | "light";
 
 type ThemeProviderProps = {
-  children: React.ReactNode
-  defaultTheme?: Theme
-  storageKey?: string
-}
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+  storageKey?: string;
+};
 
 type ThemeProviderState = {
-  theme: Theme
-  resolvedTheme: ResolvedTheme
-  setTheme: (theme: Theme) => void
-}
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+};
 
-const SYSTEM_DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)"
+const SYSTEM_DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+
+const isValidTheme = (value: unknown): value is Theme =>
+  value === "dark" || value === "light" || value === "system";
 
 const getSystemTheme = (): ResolvedTheme => {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-    return "light"
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return "light";
   }
-  return window.matchMedia(SYSTEM_DARK_MEDIA_QUERY).matches ? "dark" : "light"
-}
+  return window.matchMedia(SYSTEM_DARK_MEDIA_QUERY).matches ? "dark" : "light";
+};
 
 const initialState: ThemeProviderState = {
   theme: "system",
   resolvedTheme: "light",
   setTheme: () => null,
-}
+};
 
-export const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+export const ThemeProviderContext =
+  createContext<ThemeProviderState>(initialState);
 
 export function ThemeProvider({
   children,
@@ -38,50 +45,54 @@ export function ThemeProvider({
   storageKey = "vite-ui-theme",
   ...props
 }: Readonly<ThemeProviderProps>) {
-  const [theme, setTheme] = useState<Theme>(
-    () => (sessionStorage.getItem(storageKey) as Theme) || defaultTheme
-  )
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = sessionStorage.getItem(storageKey);
+    return isValidTheme(stored) ? stored : defaultTheme;
+  });
   const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
-    getSystemTheme()
-  )
+    getSystemTheme(),
+  );
 
   useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
     }
-    const mediaQuery = window.matchMedia(SYSTEM_DARK_MEDIA_QUERY)
+    const mediaQuery = window.matchMedia(SYSTEM_DARK_MEDIA_QUERY);
     const handleChange = (event: MediaQueryListEvent) => {
-      setSystemTheme(event.matches ? "dark" : "light")
-    }
-    mediaQuery.addEventListener("change", handleChange)
+      setSystemTheme(event.matches ? "dark" : "light");
+    };
+    mediaQuery.addEventListener("change", handleChange);
     return () => {
-      mediaQuery.removeEventListener("change", handleChange)
-    }
-  }, [])
+      mediaQuery.removeEventListener("change", handleChange);
+    };
+  }, []);
 
-  const resolvedTheme: ResolvedTheme = theme === "system" ? systemTheme : theme
+  const resolvedTheme: ResolvedTheme = theme === "system" ? systemTheme : theme;
 
   useEffect(() => {
-    const root = window.document.documentElement
-    root.classList.remove("light", "dark")
-    root.classList.add(resolvedTheme)
-  }, [resolvedTheme])
+    const root = window.document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(resolvedTheme);
+  }, [resolvedTheme]);
 
   const value = useMemo(
     () => ({
       theme,
       resolvedTheme,
       setTheme: (nextTheme: Theme) => {
-        sessionStorage.setItem(storageKey, nextTheme)
-        setTheme(nextTheme)
+        sessionStorage.setItem(storageKey, nextTheme);
+        setTheme(nextTheme);
       },
     }),
-    [theme, resolvedTheme, storageKey]
-  )
+    [theme, resolvedTheme, storageKey],
+  );
 
   return (
     <ThemeProviderContext.Provider {...props} value={value}>
       {children}
     </ThemeProviderContext.Provider>
-  )
+  );
 }


### PR DESCRIPTION
This pull request updates the application's theme system to better support system-level dark mode detection and switching. It introduces a `resolvedTheme` concept, improves how theme preferences are stored and applied, and simplifies the theme toggle logic in the header.

**Theme system improvements:**

* Added a `resolvedTheme` property to the theme context, which reflects the actual theme in use ("dark" or "light"), whether set explicitly or determined by the system setting. This allows components to reliably know which theme is currently active. [[1]](diffhunk://#diff-1bed3fc439f24021fc87f47cdb686c80a7cbda163c14618e8fcd9b92e683b161R4) [[2]](diffhunk://#diff-1bed3fc439f24021fc87f47cdb686c80a7cbda163c14618e8fcd9b92e683b161R14-R25)
* Switched theme preference storage from `localStorage` to `sessionStorage` for more predictable session-based behavior.
* Improved system theme detection by listening to the `prefers-color-scheme` media query and updating the theme dynamically if the system preference changes while the app is open.
* Updated the `ThemeProvider` to always apply the correct theme class (`light` or `dark`) to the document root based on the resolved theme, ensuring consistent styling.
* Changed the default theme in the main `App` component to "system" (instead of "light") for a better out-of-the-box user experience that respects the user's OS preference.

**Header component simplification:**

* Simplified the dark mode toggle logic in the `Header` by removing redundant state and using `resolvedTheme` to determine the current mode, leading to more reliable and maintainable code. [[1]](diffhunk://#diff-fd6214705ad0e847013e7fd7ef638240a862316ce81d39c68e882b3511b39c76L19-R25) [[2]](diffhunk://#diff-fd6214705ad0e847013e7fd7ef638240a862316ce81d39c68e882b3511b39c76L61)