### PR TITLE
fix: authentification loop on multiple logged in profiles

### DIFF
--- a/.github/workflows/release-myworkid.yml
+++ b/.github/workflows/release-myworkid.yml
@@ -39,6 +39,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || github.ref_name != 'main' }}
     permissions:
       contents: write
+      actions: read
     uses: c4a8/c4a8-code-reusable-actions/.github/workflows/epoch-semver-version.yml@eafb1e2c28580ce3f27d89848f3fd6eaacb9253a # epoch-semver-versioning-v2.0.0
     with:
       is_prerelease: true

--- a/.github/workflows/release-myworkid.yml
+++ b/.github/workflows/release-myworkid.yml
@@ -26,7 +26,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
 
 env:
   BINARY_ARTIFACT_NAME: binaries
@@ -39,8 +38,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || github.ref_name != 'main' }}
     permissions:
       contents: write
-      actions: read
-    uses: c4a8/c4a8-code-reusable-actions/.github/workflows/epoch-semver-version.yml@eafb1e2c28580ce3f27d89848f3fd6eaacb9253a # epoch-semver-versioning-v2.0.0
+    uses: c4a8/c4a8-code-reusable-actions/.github/workflows/epoch-semver-version.yml@f321371669a3ac3d19bf081e01ce57c9fae364d8 # epoch-semver-versioning-v2.1.1
     with:
       is_prerelease: true
       is_draft_release: true

--- a/src/MyWorkID.Client/src/app-authentication.tsx
+++ b/src/MyWorkID.Client/src/app-authentication.tsx
@@ -22,11 +22,16 @@ export const AppAuthentication = (props: AppAuthenticationProps) => {
   const [msalInfo, setMsalInfo] = useState<TMsalInfo>();
 
   const initializeMsalInfo = async (): Promise<TMsalInfo> => {
-    const info = await getMsalInfo();
+    const msalInformation = await getMsalInfo();
     await handleRedirectPromise();
-    await getActiveMsalAccount();
 
-    return info;
+    const activeAccount = msalInformation.msalInstance.getActiveAccount();
+    const cachedAccounts = msalInformation.msalInstance.getAllAccounts();
+    if (activeAccount || cachedAccounts.length > 0) {
+      await getActiveMsalAccount();
+    }
+
+    return msalInformation;
   };
 
   // Ensures an active account is set when accounts are already cached.

--- a/src/MyWorkID.Client/src/app-authentication.tsx
+++ b/src/MyWorkID.Client/src/app-authentication.tsx
@@ -7,7 +7,12 @@ import {
 import { InteractionType } from "@azure/msal-browser";
 import { ReactNode, useEffect, useState } from "react";
 import { SignedInUserProvider } from "./contexts/signed-in-user-provider";
-import { TMsalInfo, getMsalInfo } from "./services/msal-service";
+import {
+  TMsalInfo,
+  getActiveMsalAccount,
+  getMsalInfo,
+  handleRedirectPromise,
+} from "./services/msal-service";
 
 export type AppAutenticationProps = {
   children: ReactNode;
@@ -16,15 +21,29 @@ export type AppAutenticationProps = {
 export const AppAutentication = (props: AppAutenticationProps) => {
   const [msalInfo, setMsalInfo] = useState<TMsalInfo>();
 
+  // Ensures an active account is set when accounts are already cached.
+  // If multiple accounts are cached without an active one, this triggers
+  // a loginRedirect and the page navigates away before setMsalInfo runs.
   useEffect(() => {
-    getMsalInfo().then((_msalInfo) => {
-      setMsalInfo(_msalInfo);
-    });
+    const initialize = async () => {
+      const info = await getMsalInfo();
+      // Process any pending redirect first so the active account gets set
+      await handleRedirectPromise();
+      try {
+        await getActiveMsalAccount();
+      } catch (error) {
+        if (import.meta.env.DEV) {
+          console.debug("No active account resolved during app init", error);
+        }
+      }
+      setMsalInfo(info);
+    };
+    initialize();
   }, []);
 
   if (!msalInfo) {
     return <div>Loading</div>;
-  } else if(msalInfo.msalInstance) {
+  } else if (msalInfo.msalInstance) {
     return (
       <MsalProvider instance={msalInfo.msalInstance}>
         <MsalAuthenticationTemplate

--- a/src/MyWorkID.Client/src/app-authentication.tsx
+++ b/src/MyWorkID.Client/src/app-authentication.tsx
@@ -14,37 +14,28 @@ import {
   handleRedirectPromise,
 } from "./services/msal-service";
 
-export type AppAutenticationProps = {
+export type AppAuthenticationProps = {
   children: ReactNode;
 };
 
-export const AppAutentication = (props: AppAutenticationProps) => {
+export const AppAuthentication = (props: AppAuthenticationProps) => {
   const [msalInfo, setMsalInfo] = useState<TMsalInfo>();
+
+  const initializeMsalInfo = async (): Promise<TMsalInfo> => {
+    const info = await getMsalInfo();
+    await handleRedirectPromise();
+    await getActiveMsalAccount();
+
+    return info;
+  };
 
   // Ensures an active account is set when accounts are already cached.
   // If multiple accounts are cached without an active one, this triggers
   // a loginRedirect and the page navigates away before setMsalInfo runs.
   useEffect(() => {
-    const initialize = async () => {
-      const info = await getMsalInfo();
-      // Process any pending redirect first so the active account gets set.
-      try {
-        await handleRedirectPromise();
-      } catch (error) {
-        if (import.meta.env.DEV) {
-          console.debug("handleRedirectPromise failed during app init", error);
-        }
-      }
-      try {
-        await getActiveMsalAccount();
-      } catch (error) {
-        if (import.meta.env.DEV) {
-          console.debug("No active account resolved during app init", error);
-        }
-      }
-      setMsalInfo(info);
-    };
-    initialize();
+    initializeMsalInfo().then((resolvedMsalInfo) => {
+      setMsalInfo(resolvedMsalInfo);
+    });
   }, []);
 
   if (!msalInfo) {

--- a/src/MyWorkID.Client/src/app-authentication.tsx
+++ b/src/MyWorkID.Client/src/app-authentication.tsx
@@ -27,8 +27,14 @@ export const AppAutentication = (props: AppAutenticationProps) => {
   useEffect(() => {
     const initialize = async () => {
       const info = await getMsalInfo();
-      // Process any pending redirect first so the active account gets set
-      await handleRedirectPromise();
+      // Process any pending redirect first so the active account gets set.
+      try {
+        await handleRedirectPromise();
+      } catch (error) {
+        if (import.meta.env.DEV) {
+          console.debug("handleRedirectPromise failed during app init", error);
+        }
+      }
       try {
         await getActiveMsalAccount();
       } catch (error) {

--- a/src/MyWorkID.Client/src/contexts/signed-in-user-provider.tsx
+++ b/src/MyWorkID.Client/src/contexts/signed-in-user-provider.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useEffect } from "react";
 import { parseRoles } from "../services/roles-service";
-import { getMsalInfo } from "../services/msal-service";
+import { getActiveMsalAccount, getMsalInfo } from "../services/msal-service";
 
 export type TSignedInUser = {
   roles: string[];
@@ -20,24 +20,18 @@ export const SignedInUserProvider = (props: SignedInUserProviderProps) => {
   const [signedInUser, setSignedInUser] = React.useState<TSignedInUser>();
 
   useEffect(() => {
-    getMsalInfo().then((msalInfo) => {
-      const accounts = msalInfo.msalInstance.getAllAccounts();
+    Promise.all([getMsalInfo(), getActiveMsalAccount()]).then(
+      ([msalInfo, activeAccount]) => {
+        const request = {
+          scopes: [`api://${msalInfo.backendClientId}/Access`],
+          account: activeAccount,
+        };
 
-      if (accounts.length === 0) {
-        throw new Error(
-          "User not signed in. SignedInUserProvider is only allowed to be used inside of an Authenticated context"
-        );
+        msalInfo.msalInstance.acquireTokenSilent(request).then((result) => {
+          setSignedInUser({ roles: parseRoles(result.accessToken) });
+        });
       }
-
-      const request = {
-        scopes: [`api://${msalInfo.backendClientId}/Access`],
-        account: accounts[0],
-      };
-
-      msalInfo?.msalInstance.acquireTokenSilent(request).then((result) => {
-        setSignedInUser({ roles: parseRoles(result.accessToken) });
-      });
-    });
+    );
   }, []);
 
   return (

--- a/src/MyWorkID.Client/src/main.tsx
+++ b/src/MyWorkID.Client/src/main.tsx
@@ -3,21 +3,21 @@ import ReactDOM from "react-dom/client";
 import "./assets/css/main.css";
 import "./assets/css/custom.css";
 import { BrowserRouter } from "react-router-dom";
-import { AppAutentication } from "./app-authentication";
+import { AppAuthentication } from "./app-authentication";
 import App from "./app";
 import { Toaster } from "./components/ui/toaster";
 
 const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
+  document.getElementById("root") as HTMLElement,
 );
 
 root.render(
   <BrowserRouter>
     <React.StrictMode>
-      <AppAutentication>
+      <AppAuthentication>
         <App />
         <Toaster />
-      </AppAutentication>
+      </AppAuthentication>
     </React.StrictMode>
-  </BrowserRouter>
+  </BrowserRouter>,
 );

--- a/src/MyWorkID.Client/src/services/msal-service.ts
+++ b/src/MyWorkID.Client/src/services/msal-service.ts
@@ -1,5 +1,6 @@
 import {
   PublicClientApplication,
+  AccountInfo,
   AuthenticationResult,
   LogLevel,
 } from "@azure/msal-browser";
@@ -66,6 +67,33 @@ export const getMsalInfo = async (): Promise<TMsalInfo> => {
   });
 };
 
+// Resolves the account MSAL should use for every token acquisition. Prefers the
+// explicitly-set active account. On multiple signed in accounts, prompts the
+// user to select one.
+export const getActiveMsalAccount = async (): Promise<AccountInfo> => {
+  const msalInfo = await getMsalInfo();
+  const activeAccount = msalInfo.msalInstance.getActiveAccount();
+  if (activeAccount) {
+    return activeAccount;
+  }
+
+  const accounts = msalInfo.msalInstance.getAllAccounts();
+  if (accounts.length === 0) {
+    throw new Error("User not signed in");
+  }
+  if (accounts.length === 1) {
+    msalInfo.msalInstance.setActiveAccount(accounts[0]);
+    return accounts[0];
+  }
+
+  await msalInfo.msalInstance.loginRedirect({
+    prompt: "select_account",
+    scopes: [`api://${msalInfo.backendClientId}/Access`],
+  });
+  // Should never throw since loginRedirect navigates away from the page.
+  throw new Error("Multiple accounts cached - prompting account selection");
+};
+
 export const sendAxiosRequest = async <T, D = unknown>(
   url: string,
   requestType: REQUEST_TYPE,
@@ -118,10 +146,13 @@ export const authenticateRequest = async <T, D = undefined>(
       );
 
       const msalInfo = await getMsalInfo();
+      const activeAccount = await getActiveMsalAccount();
       await msalInfo.msalInstance.acquireTokenRedirect({
         claims: window.atob(wwwAuthenticateHeader.claims), // decode the base64 string
         scopes: [`api://${msalInfo.backendClientId}/Access`],
         state: redirectState,
+        account: activeAccount,
+        loginHint: activeAccount.username,
       });
     } else {
       throw error;
@@ -132,15 +163,11 @@ export const authenticateRequest = async <T, D = undefined>(
 
 const getBearerToken = async (): Promise<string> => {
   const msalInfo = await getMsalInfo();
-  const accounts = msalInfo.msalInstance.getAllAccounts();
-
-  if (accounts.length === 0) {
-    throw new Error("User not signed in");
-  }
+  const activeAccount = await getActiveMsalAccount();
 
   const request = {
     scopes: [`api://${msalInfo.backendClientId}/Access`],
-    account: accounts[0],
+    account: activeAccount,
   };
 
   const authResult = await msalInfo.msalInstance
@@ -149,6 +176,8 @@ const getBearerToken = async (): Promise<string> => {
       console.warn("acquire token silently failed", error);
       await msalInfo.msalInstance.acquireTokenRedirect({
         scopes: [`api://${msalInfo.backendClientId}/Access`],
+        account: activeAccount,
+        loginHint: activeAccount.username,
       });
     });
   if (authResult) {
@@ -160,15 +189,11 @@ const getBearerToken = async (): Promise<string> => {
 
 export const getGraphBearerToken = async (): Promise<string> => {
   const msalInfo = await getMsalInfo();
-  const accounts = msalInfo.msalInstance.getAllAccounts();
-
-  if (accounts.length === 0) {
-    throw new Error("User not signed in");
-  }
+  const activeAccount = await getActiveMsalAccount();
 
   const request = {
     scopes: [`https://graph.microsoft.com/User.Read`],
-    account: accounts[0],
+    account: activeAccount,
   };
 
   const authResult = await msalInfo.msalInstance
@@ -177,6 +202,8 @@ export const getGraphBearerToken = async (): Promise<string> => {
       console.warn("acquire token silently failed", error);
       await msalInfo.msalInstance.acquireTokenRedirect({
         scopes: [`https://graph.microsoft.com/User.Read`],
+        account: activeAccount,
+        loginHint: activeAccount.username,
       });
     });
   if (authResult) {
@@ -189,7 +216,12 @@ export const getGraphBearerToken = async (): Promise<string> => {
 export const handleRedirectPromise =
   async (): Promise<AuthenticationResult | null> => {
     const msalInfo = await getMsalInfo();
-    return await msalInfo.msalInstance.handleRedirectPromise();
+    const authenticationResult =
+      await msalInfo.msalInstance.handleRedirectPromise();
+    if (authenticationResult?.account) {
+      msalInfo.msalInstance.setActiveAccount(authenticationResult.account);
+    }
+    return authenticationResult;
   };
 
 export const getPendingAction = (

--- a/src/MyWorkID.Client/src/services/msal-service.ts
+++ b/src/MyWorkID.Client/src/services/msal-service.ts
@@ -213,15 +213,22 @@ export const getGraphBearerToken = async (): Promise<string> => {
   }
 };
 
+// Memoize MSAL redirect response to let every caller observe the same one
+let redirectPromiseCache: Promise<AuthenticationResult | null> | undefined =
+  undefined;
+
 export const handleRedirectPromise =
-  async (): Promise<AuthenticationResult | null> => {
-    const msalInfo = await getMsalInfo();
-    const authenticationResult =
-      await msalInfo.msalInstance.handleRedirectPromise();
-    if (authenticationResult?.account) {
-      msalInfo.msalInstance.setActiveAccount(authenticationResult.account);
-    }
-    return authenticationResult;
+  (): Promise<AuthenticationResult | null> => {
+    redirectPromiseCache ??= (async () => {
+      const msalInfo = await getMsalInfo();
+      const authenticationResult =
+        await msalInfo.msalInstance.handleRedirectPromise();
+      if (authenticationResult?.account) {
+        msalInfo.msalInstance.setActiveAccount(authenticationResult.account);
+      }
+      return authenticationResult;
+    })();
+    return redirectPromiseCache;
   };
 
 export const getPendingAction = (


### PR DESCRIPTION
This pull request improves authentication handling in the MSAL integration by consistently resolving and setting the active account before acquiring tokens. This ensures the correct user context is used, especially when multiple accounts are cached, and prevents issues where no active account is set. Several utility methods are updated or added to streamline this process, and related components are refactored to use these improvements.

**Authentication and Account Selection Improvements**
* Added `getActiveMsalAccount` to consistently resolve the active MSAL account, prompting the user to select one if multiple accounts are cached, and integrated it throughout the authentication flow. [[1]](diffhunk://#diff-d5620416e36bfe70114e6277fc8be82228c16d132b8105fd070624260dbc0d10R70-R96) [[2]](diffhunk://#diff-d5620416e36bfe70114e6277fc8be82228c16d132b8105fd070624260dbc0d10L135-R170) [[3]](diffhunk://#diff-d5620416e36bfe70114e6277fc8be82228c16d132b8105fd070624260dbc0d10L163-R196) [[4]](diffhunk://#diff-d5620416e36bfe70114e6277fc8be82228c16d132b8105fd070624260dbc0d10L192-R224) [[5]](diffhunk://#diff-d5620416e36bfe70114e6277fc8be82228c16d132b8105fd070624260dbc0d10R205-R206)
* Updated `handleRedirectPromise` to set the active account after redirect-based authentication completes.

**Component Refactoring**
* Refactored `AppAutentication` and `SignedInUserProvider` components to use the new active account logic, ensuring the user is correctly authenticated and authorized in all cases. [[1]](diffhunk://#diff-6f4d97683a1b8e252270e0da28f9fb06d1bf454a0904fd2f820c0bbc910419a5L10-R15) [[2]](diffhunk://#diff-6f4d97683a1b8e252270e0da28f9fb06d1bf454a0904fd2f820c0bbc910419a5R24-R41) [[3]](diffhunk://#diff-8460a2742a7c90ad777cfdcb44514a5861eeeadcf4e824cee6fb38212632da16L3-R3) [[4]](diffhunk://#diff-8460a2742a7c90ad777cfdcb44514a5861eeeadcf4e824cee6fb38212632da16L23-R34)

**Token Acquisition Updates**
* Updated all token acquisition flows (`getBearerToken`, `getGraphBearerToken`, and `authenticateRequest`) to use the resolved active account, passing it explicitly to MSAL methods and including `loginHint` for better UX. [[1]](diffhunk://#diff-d5620416e36bfe70114e6277fc8be82228c16d132b8105fd070624260dbc0d10L135-R170) [[2]](diffhunk://#diff-d5620416e36bfe70114e6277fc8be82228c16d132b8105fd070624260dbc0d10R179-R180) [[3]](diffhunk://#diff-d5620416e36bfe70114e6277fc8be82228c16d132b8105fd070624260dbc0d10L163-R196) [[4]](diffhunk://#diff-d5620416e36bfe70114e6277fc8be82228c16d132b8105fd070624260dbc0d10R205-R206)

**Workflow Permissions**
* Added `actions: read` permission to the release workflow to align with best practices.