### PR TITLE
fix: prevent stale SPA content after deployment

### DIFF
--- a/src/MyWorkID.Server/Program.cs
+++ b/src/MyWorkID.Server/Program.cs
@@ -46,20 +46,25 @@ app.Use(async (context, next) =>
     context.Response.OnStarting(() =>
     {
         string requestPath = context.Request.Path.Value ?? string.Empty;
-        if (requestPath.StartsWith("/assets", StringComparison.OrdinalIgnoreCase))
-        {
-            context.Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
-        }
-        else if (
+
+        bool isHtml =
             context.Response.ContentType?.StartsWith(
                 "text/html",
                 StringComparison.OrdinalIgnoreCase
-            ) == true
-        )
+            ) == true;
+
+        if (isHtml)
         {
             context.Response.Headers["Cache-Control"] = "no-store, max-age=0";
             context.Response.Headers["Pragma"] = "no-cache";
             context.Response.Headers["Expires"] = "0";
+        }
+        else if (
+            requestPath.Equals("/assets", StringComparison.OrdinalIgnoreCase)
+            || requestPath.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            context.Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
         }
 
         return Task.CompletedTask;

--- a/src/MyWorkID.Server/Program.cs
+++ b/src/MyWorkID.Server/Program.cs
@@ -43,21 +43,27 @@ WebApplication app = builder.Build();
 
 app.Use(async (context, next) =>
 {
-    string requestPath = context.Request.Path.Value ?? string.Empty;
-    if (
-        requestPath == "/"
-        || requestPath.Equals("/index.html", StringComparison.OrdinalIgnoreCase)
-        || !Path.HasExtension(requestPath)
-    )
+    context.Response.OnStarting(() =>
     {
-        context.Response.Headers["Cache-Control"] = "no-store, max-age=0";
-        context.Response.Headers["Pragma"] = "no-cache";
-        context.Response.Headers["Expires"] = "0";
-    }
-    else if (requestPath.StartsWith("/assets", StringComparison.OrdinalIgnoreCase))
-    {
-        context.Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
-    }
+        string requestPath = context.Request.Path.Value ?? string.Empty;
+        if (requestPath.StartsWith("/assets", StringComparison.OrdinalIgnoreCase))
+        {
+            context.Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
+        }
+        else if (
+            context.Response.ContentType?.StartsWith(
+                "text/html",
+                StringComparison.OrdinalIgnoreCase
+            ) == true
+        )
+        {
+            context.Response.Headers["Cache-Control"] = "no-store, max-age=0";
+            context.Response.Headers["Pragma"] = "no-cache";
+            context.Response.Headers["Expires"] = "0";
+        }
+
+        return Task.CompletedTask;
+    });
 
     await next();
 });

--- a/src/MyWorkID.Server/Program.cs
+++ b/src/MyWorkID.Server/Program.cs
@@ -41,44 +41,26 @@ builder.Services.ConfigureModules(builder.Configuration, builder.Environment, ap
 
 WebApplication app = builder.Build();
 
-app.Use(async (context, next) =>
+// OnPrepareResponse only runs for files that are actually served, so error responses are never cached.
+StaticFileOptions staticFileOptions = new StaticFileOptions
 {
-    context.Response.OnStarting(() =>
+    OnPrepareResponse = ctx =>
     {
-        string requestPath = context.Request.Path.Value ?? string.Empty;
-
-        bool isHtml =
-            context.Response.ContentType?.StartsWith(
-                "text/html",
-                StringComparison.OrdinalIgnoreCase
-            ) == true;
-
-        if (isHtml)
+        if (ctx.Context.Request.Path.StartsWithSegments("/assets"))
         {
-            context.Response.Headers["Cache-Control"] = "no-store, max-age=0";
-            context.Response.Headers["Pragma"] = "no-cache";
-            context.Response.Headers["Expires"] = "0";
+            // Fingerprinted build assets: filename changes on content change.
+            ctx.Context.Response.Headers["Cache-Control"] =
+                "public, max-age=31536000, immutable";
         }
-        else if (
-            context.Response.StatusCode >= StatusCodes.Status200OK
-            && context.Response.StatusCode < StatusCodes.Status300MultipleChoices
-            && (
-            requestPath.Equals("/assets", StringComparison.OrdinalIgnoreCase)
-            || requestPath.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase)
-            )
-        )
+        else if (ctx.File.Name.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
         {
-            context.Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
+            ctx.Context.Response.Headers["Cache-Control"] = "no-store, max-age=0";
         }
-
-        return Task.CompletedTask;
-    });
-
-    await next();
-});
+    },
+};
 
 app.UseDefaultFiles();
-app.UseStaticFiles();
+app.UseStaticFiles(staticFileOptions);
 
 app.UseExceptionHandler(exceptionHandlerApp =>
 {
@@ -137,6 +119,6 @@ app.UseAuthorization();
 app.RegisterEndpoints(appAssembly);
 
 app.MapHub<VerifiedIdHub>("/hubs/verifiedId");
-app.MapFallbackToFile("/index.html");
+app.MapFallbackToFile("/index.html", staticFileOptions);
 
 await app.RunAsync();

--- a/src/MyWorkID.Server/Program.cs
+++ b/src/MyWorkID.Server/Program.cs
@@ -44,17 +44,23 @@ WebApplication app = builder.Build();
 // OnPrepareResponse only runs for files that are actually served, so error responses are never cached.
 StaticFileOptions staticFileOptions = new StaticFileOptions
 {
-    OnPrepareResponse = ctx =>
+    OnPrepareResponse = staticFileResponseContext =>
     {
-        if (ctx.Context.Request.Path.StartsWithSegments("/assets"))
+        if (staticFileResponseContext.Context.Request.Path.StartsWithSegments("/assets"))
         {
             // Fingerprinted build assets: filename changes on content change.
-            ctx.Context.Response.Headers["Cache-Control"] =
+            staticFileResponseContext.Context.Response.Headers["Cache-Control"] =
                 "public, max-age=31536000, immutable";
         }
-        else if (ctx.File.Name.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
+        else if (
+            staticFileResponseContext.File.Name.EndsWith(
+                ".html",
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
         {
-            ctx.Context.Response.Headers["Cache-Control"] = "no-store, max-age=0";
+            staticFileResponseContext.Context.Response.Headers["Cache-Control"] =
+                "no-store, max-age=0";
         }
     },
 };

--- a/src/MyWorkID.Server/Program.cs
+++ b/src/MyWorkID.Server/Program.cs
@@ -41,6 +41,27 @@ builder.Services.ConfigureModules(builder.Configuration, builder.Environment, ap
 
 WebApplication app = builder.Build();
 
+app.Use(async (context, next) =>
+{
+    PathString requestPath = context.Request.Path;
+    if (
+        requestPath == "/"
+        || requestPath.Equals("/index.html", StringComparison.OrdinalIgnoreCase)
+        || !Path.HasExtension(requestPath)
+    )
+    {
+        context.Response.Headers.CacheControl = "no-store, max-age=0";
+        context.Response.Headers.Pragma = "no-cache";
+        context.Response.Headers.Expires = "0";
+    }
+    else if (requestPath.StartsWithSegments("/assets"))
+    {
+        context.Response.Headers.CacheControl = "public, max-age=31536000, immutable";
+    }
+
+    await next();
+});
+
 app.UseDefaultFiles();
 app.UseStaticFiles();
 

--- a/src/MyWorkID.Server/Program.cs
+++ b/src/MyWorkID.Server/Program.cs
@@ -60,8 +60,12 @@ app.Use(async (context, next) =>
             context.Response.Headers["Expires"] = "0";
         }
         else if (
+            context.Response.StatusCode >= StatusCodes.Status200OK
+            && context.Response.StatusCode < StatusCodes.Status300MultipleChoices
+            && (
             requestPath.Equals("/assets", StringComparison.OrdinalIgnoreCase)
             || requestPath.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase)
+            )
         )
         {
             context.Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";

--- a/src/MyWorkID.Server/Program.cs
+++ b/src/MyWorkID.Server/Program.cs
@@ -43,20 +43,20 @@ WebApplication app = builder.Build();
 
 app.Use(async (context, next) =>
 {
-    PathString requestPath = context.Request.Path;
+    string requestPath = context.Request.Path.Value ?? string.Empty;
     if (
         requestPath == "/"
         || requestPath.Equals("/index.html", StringComparison.OrdinalIgnoreCase)
         || !Path.HasExtension(requestPath)
     )
     {
-        context.Response.Headers.CacheControl = "no-store, max-age=0";
-        context.Response.Headers.Pragma = "no-cache";
-        context.Response.Headers.Expires = "0";
+        context.Response.Headers["Cache-Control"] = "no-store, max-age=0";
+        context.Response.Headers["Pragma"] = "no-cache";
+        context.Response.Headers["Expires"] = "0";
     }
-    else if (requestPath.StartsWithSegments("/assets"))
+    else if (requestPath.StartsWith("/assets", StringComparison.OrdinalIgnoreCase))
     {
-        context.Response.Headers.CacheControl = "public, max-age=31536000, immutable";
+        context.Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
     }
 
     await next();

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,3 +1,3 @@
 output "update_commands" {
-  value = "az webapp deploy -g '${azurerm_resource_group.main.name}' -n '${azurerm_linux_web_app.backend.name}' --src-path binaries.zip \naz webapp restart --resource-group '${azurerm_resource_group.main.name}' --name '${azurerm_linux_web_app.backend.name}'"
+  value = "az webapp deploy -g '${azurerm_resource_group.main.name}' -n '${azurerm_linux_web_app.backend.name}' --src-path binaries.zip --restart true && az webapp restart --resource-group '${azurerm_resource_group.main.name}' --name '${azurerm_linux_web_app.backend.name}' && curl --fail --retry 12 --retry-all-errors --retry-delay 5 'https://${azurerm_linux_web_app.backend.default_hostname}/health/'"
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,3 +1,3 @@
 output "update_commands" {
-  value = "az webapp deploy -g '${azurerm_resource_group.main.name}' -n '${azurerm_linux_web_app.backend.name}' --src-path binaries.zip --restart true && az webapp restart --resource-group '${azurerm_resource_group.main.name}' --name '${azurerm_linux_web_app.backend.name}' && curl --fail --retry 12 --retry-all-errors --retry-delay 5 'https://${azurerm_linux_web_app.backend.default_hostname}/api/general'"
+  value = "az webapp deploy -g '${azurerm_resource_group.main.name}' -n '${azurerm_linux_web_app.backend.name}' --src-path binaries.zip && az webapp restart --resource-group '${azurerm_resource_group.main.name}' --name '${azurerm_linux_web_app.backend.name}' && curl --fail --max-time 10 --retry 12 --retry-all-errors --retry-delay 5 'https://${azurerm_linux_web_app.backend.default_hostname}/api/general'"
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,3 +1,3 @@
 output "update_commands" {
-  value = "az webapp deploy -g '${azurerm_resource_group.main.name}' -n '${azurerm_linux_web_app.backend.name}' --src-path binaries.zip --restart true && az webapp restart --resource-group '${azurerm_resource_group.main.name}' --name '${azurerm_linux_web_app.backend.name}' && curl --fail --retry 12 --retry-all-errors --retry-delay 5 'https://${azurerm_linux_web_app.backend.default_hostname}/health/'"
+  value = "az webapp deploy -g '${azurerm_resource_group.main.name}' -n '${azurerm_linux_web_app.backend.name}' --src-path binaries.zip --restart true && az webapp restart --resource-group '${azurerm_resource_group.main.name}' --name '${azurerm_linux_web_app.backend.name}' && curl --fail --retry 12 --retry-all-errors --retry-delay 5 'https://${azurerm_linux_web_app.backend.default_hostname}/api/general'"
 }


### PR DESCRIPTION
close #166 
This pull request introduces improved static file caching behavior in the server and enhances the deployment verification process in the infrastructure configuration. The most significant changes are grouped below:

**Server-side static file caching improvements:**

* Added custom `StaticFileOptions` in `Program.cs` to set long-term caching headers for fingerprinted assets in the `/assets` directory, and to prevent caching of `.html` files by setting appropriate `Cache-Control` headers. This helps ensure users always get the latest HTML while allowing aggressive caching of static assets.
* Updated the static file middleware and fallback mapping to use the new `staticFileOptions`, ensuring consistent caching behavior for both direct and fallback static file requests. [[1]](diffhunk://#diff-35974d2300c458481354a31b2b06508bdb641e86ba6107ba94421b59bbec25aaR44-R63) [[2]](diffhunk://#diff-35974d2300c458481354a31b2b06508bdb641e86ba6107ba94421b59bbec25aaL104-R122)

**Infrastructure/deployment enhancements:**

* Modified the `update_commands` Terraform output to use `&&` instead of `\n` between commands, and added a `curl` command to verify the deployment by hitting the `/api/general` endpoint. This ensures that the deployment is validated immediately after restart.