### PR TITLE
ci: switch to reusable actions and fix link of release automation

### DIFF
--- a/.github/workflows/release-myworkid.yml
+++ b/.github/workflows/release-myworkid.yml
@@ -149,3 +149,13 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to publish release with id '$env:RELEASE_ID'. GitHub response: $($ReleaseResponse | Out-String)"
           }
+
+          # Update release link after setting draft release to productive in workflow summary
+          $PublishedRelease = $ReleaseResponse | Out-String | ConvertFrom-Json
+          $PublishedReleaseUrl = $PublishedRelease.html_url
+
+          if ([string]::IsNullOrWhiteSpace($PublishedReleaseUrl)) {
+            throw "Failed to update html_url in release summary for release id '$env:RELEASE_ID'."
+          }
+
+          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "## Published release`n[$($PublishedRelease.tag_name)]($PublishedReleaseUrl)"

--- a/.github/workflows/release-myworkid.yml
+++ b/.github/workflows/release-myworkid.yml
@@ -36,14 +36,28 @@ jobs:
     name: Generate version and draft release
     # Manual dispatches on main branch will be skipped to avoid creating a release for the same commit twice
     if: ${{ github.event_name != 'workflow_dispatch' || github.ref_name != 'main' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    uses: c4a8/c4a8-code-reusable-actions/.github/workflows/epoch-semver-version.yml@f321371669a3ac3d19bf081e01ce57c9fae364d8 # epoch-semver-versioning-v2.1.1
-    with:
-      is_prerelease: true
-      is_draft_release: true
-      suppress_release: ${{ !(github.event_name == 'push' && github.ref_name == 'main') }}
-      prerelease_name: ${{ github.ref_name != 'main' && 'internal' || '' }}
+    outputs:
+      tag: ${{ steps.generate_version.outputs.tag }}
+      release_id: ${{ steps.generate_version.outputs.release_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate version and draft release
+        id: generate_version
+        uses: glueckkanja/action-epoch-semantic-version@f1eb38a96b44a2a9ce4378257afceed2babcc6e1 # v2.1.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          is_prerelease: true
+          is_draft_release: true
+          suppress_release: ${{ !(github.event_name == 'push' && github.ref_name == 'main') }}
+          prerelease_name: ${{ github.ref_name != 'main' && 'internal' || '' }}
 
   build_myworkid_binaries:
     needs:

--- a/.github/workflows/release-myworkid.yml
+++ b/.github/workflows/release-myworkid.yml
@@ -150,12 +150,12 @@ jobs:
             throw "Failed to publish release with id '$env:RELEASE_ID'. GitHub response: $($ReleaseResponse | Out-String)"
           }
 
-          # Update release link after setting draft release to productive in workflow summary
+          # Publish new release link after setting draft release to productive in workflow summary
           $PublishedRelease = $ReleaseResponse | Out-String | ConvertFrom-Json
           $PublishedReleaseUrl = $PublishedRelease.html_url
 
           if ([string]::IsNullOrWhiteSpace($PublishedReleaseUrl)) {
-            throw "Failed to update html_url in release summary for release id '$env:RELEASE_ID'."
+            throw "Failed to publish new html_url in release summary for release id '$env:RELEASE_ID'."
           }
 
-          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "## Published release`n[$($PublishedRelease.tag_name)]($PublishedReleaseUrl)"
+          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "## Published release (supersedes draft link above)`n[$($PublishedRelease.tag_name)]($PublishedReleaseUrl)"

--- a/.github/workflows/release-myworkid.yml
+++ b/.github/workflows/release-myworkid.yml
@@ -64,7 +64,7 @@ jobs:
       - generate_version
     permissions:
       contents: read
-    uses: ./.github/workflows/build-binaries-reusable.yml
+    uses: $/.github/workflows/build-binaries-reusable.yml
     with:
       version: ${{ needs.generate_version.outputs.tag }}
 

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -55,4 +55,4 @@ jobs:
       contents: read
       actions: read
       checks: write
-    uses: ./.github/workflows/test-report.yml
+    uses: $/.github/workflows/test-report.yml


### PR DESCRIPTION
This pull request updates the release workflow to improve how releases are generated and how release information is surfaced in the workflow summary. The main changes include switching to a new action for version and release generation, and enhancing the workflow summary with a direct link to the published release.

**Release process improvements:**

* Replaced the reusable workflow with the `glueckkanja/action-epoch-semantic-version` action for generating the version and drafting releases, allowing for more control and custom outputs (`tag`, `release_id`). Also added a checkout step to ensure the workflow has access to the repository. (.github/workflows/release-myworkid.yml)

**Workflow summary enhancements:**

* After publishing a release, the workflow now extracts the release URL and adds a formatted link to the workflow summary, making it easier to find and access the published release directly from the summary. (.github/workflows/release-myworkid.yml)

closes #163 