### PR TITLE
deps: update nuget packages

### DIFF
--- a/.github/workflows/release-myworkid.yml
+++ b/.github/workflows/release-myworkid.yml
@@ -50,7 +50,7 @@ jobs:
       - generate_version
     permissions:
       contents: read
-    uses: ./.github/workflows/build-binaries-reusable.yml
+    uses: $/.github/workflows/build-binaries-reusable.yml
     with:
       version: ${{ needs.generate_version.outputs.tag }}
 

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -51,4 +51,4 @@ jobs:
       contents: read
       actions: read
       checks: write
-    uses: ./.github/workflows/test-report.yml
+    uses: $/.github/workflows/test-report.yml

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -33,13 +33,13 @@ jobs:
           dotnet build --configuration Release --no-restore
       - name: Test
         run: |
-          dotnet test --logger "trx;logfilename=testResults.trx"
+          dotnet test --configuration Release --no-build --report-xunit-trx --report-xunit-trx-filename testResults.trx
       - name: Gather Test Results
         if: success() || failure()
         run: |
           mkdir TestResults
-          cp tests/MyWorkID.Server.IntegrationTests/TestResults/testResults.trx TestResults/Integration-Tests.trx
-          cp tests/MyWorkID.Server.UnitTests/TestResults/testResults.trx TestResults/Unit-Tests.trx
+          cp tests/MyWorkID.Server.IntegrationTests/bin/Release/net10.0/TestResults/testResults.trx TestResults/Integration-Tests.trx
+          cp tests/MyWorkID.Server.UnitTests/bin/Release/net10.0/TestResults/testResults.trx TestResults/Unit-Tests.trx
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -38,8 +38,8 @@ jobs:
         if: success() || failure()
         run: |
           mkdir -p TestResults
-          cp tests/MyWorkID.Server.IntegrationTests/bin/Release/net10.0/TestResults/testResults.trx TestResults/Integration-Tests.trx
-          cp tests/MyWorkID.Server.UnitTests/bin/Release/net10.0/TestResults/testResults.trx TestResults/Unit-Tests.trx
+          cp tests/MyWorkID.Server.IntegrationTests/TestResults/testResults.trx TestResults/Integration-Tests.trx
+          cp tests/MyWorkID.Server.UnitTests/TestResults/testResults.trx TestResults/Unit-Tests.trx
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Gather Test Results
         if: success() || failure()
         run: |
-          mkdir TestResults
+          mkdir -p TestResults
           cp tests/MyWorkID.Server.IntegrationTests/bin/Release/net10.0/TestResults/testResults.trx TestResults/Integration-Tests.trx
           cp tests/MyWorkID.Server.UnitTests/bin/Release/net10.0/TestResults/testResults.trx TestResults/Unit-Tests.trx
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -32,14 +32,10 @@ jobs:
           dotnet restore
           dotnet build --configuration Release --no-restore
       - name: Test
+        shell: pwsh
         run: |
-          dotnet test --configuration Release --no-build --report-xunit-trx --report-xunit-trx-filename testResults.trx
-      - name: Gather Test Results
-        if: success() || failure()
-        run: |
-          mkdir -p TestResults
-          cp tests/MyWorkID.Server.IntegrationTests/TestResults/testResults.trx TestResults/Integration-Tests.trx
-          cp tests/MyWorkID.Server.UnitTests/TestResults/testResults.trx TestResults/Unit-Tests.trx
+          dotnet test tests/MyWorkID.Server.UnitTests --configuration Release --no-build --results-directory TestResults --report-xunit-trx --report-xunit-trx-filename Unit-Tests.trx
+          dotnet test tests/MyWorkID.Server.IntegrationTests --configuration Release --no-build --results-directory TestResults --report-xunit-trx --report-xunit-trx-filename Integration-Tests.trx
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/MyWorkID.Server/MyWorkID.Server.csproj
+++ b/src/MyWorkID.Server/MyWorkID.Server.csproj
@@ -14,11 +14,11 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy">
-      <Version>10.0.9</Version>
+      <Version>10.0.12</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Graph" Version="6.2.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.12" />
+    <PackageReference Include="Microsoft.Graph" Version="6.6.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 

--- a/tests/MyWorkID.Server.IntegrationTests/MyWorkID.Server.IntegrationTests.csproj
+++ b/tests/MyWorkID.Server.IntegrationTests/MyWorkID.Server.IntegrationTests.csproj
@@ -6,6 +6,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,11 +26,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.12" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
+    <PackageReference Include="NSubstitute" Version="6.2.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/MyWorkID.Server.UnitTests/MyWorkID.Server.UnitTests.csproj
+++ b/tests/MyWorkID.Server.UnitTests/MyWorkID.Server.UnitTests.csproj
@@ -6,6 +6,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,10 +15,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
+    <PackageReference Include="NSubstitute" Version="6.2.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request updates the test infrastructure and dependencies to improve compatibility with the latest .NET testing tools and libraries. The main changes include upgrading several NuGet packages, updating test runner configuration, and adjusting the CI workflow to accommodate these changes.

**Dependency and Package Upgrades:**

* Upgraded `Microsoft.AspNetCore.SpaProxy`, `Microsoft.Extensions.Logging.AzureAppServices`, `Microsoft.Graph`, and `Microsoft.Identity.Web` to newer versions in `MyWorkID.Server.csproj` for improved stability and features.
* Updated test-related packages (`Microsoft.NET.Test.Sdk`, `NSubstitute`, `xunit.v3`, `xunit.runner.visualstudio`) to their latest major versions in both `MyWorkID.Server.IntegrationTests.csproj` and `MyWorkID.Server.UnitTests.csproj`. [[1]](diffhunk://#diff-476b928bc7170c89228d603ab650d2a1ad8ecd697c607ee4da2d4ecf7ad1f6a8L28-R33) [[2]](diffhunk://#diff-6c10e5346a81f1227f4598042561e118f935819018fd30ffb7c3b91635c4b6d9L17-R21)
* Upgraded `Microsoft.AspNetCore.Mvc.Testing` in the integration tests project for compatibility with the latest ASP.NET Core.

**Test Runner and Platform Configuration:**

* Added a `global.json` specifying the use of `Microsoft.Testing.Platform` as the test runner, ensuring consistency across environments.
* Set the `TestingPlatformDotnetTestSupport` property to `true` in both test project files to enable support for the new testing platform. [[1]](diffhunk://#diff-476b928bc7170c89228d603ab650d2a1ad8ecd697c607ee4da2d4ecf7ad1f6a8R9) [[2]](diffhunk://#diff-6c10e5346a81f1227f4598042561e118f935819018fd30ffb7c3b91635c4b6d9R9)

**CI Workflow Adjustments:**

* Updated the GitHub Actions workflow to use the new test runner arguments and adjusted the paths for collecting test result files, reflecting changes in output locations due to the updated test SDK and runner.